### PR TITLE
spec: align the release-body contract, its authoring surfaces, and its validator

### DIFF
--- a/sops/SOP_release_process.md
+++ b/sops/SOP_release_process.md
@@ -1,6 +1,6 @@
 # SOP: Release Process
 
-**Version**: 1.33
+**Version**: 1.34
 **Created**: 2025-11-30
 **Updated**: 2026-05-09
 **Owner**: private-aget-framework-AGET
@@ -2409,7 +2409,7 @@ See: `docs/COMMUNICATION_STANDARDS.md` for full template
 
 ### Phase 5.5: Compose Release Body (CAP-REL-006-02-NN per v3.18; NEW)
 
-**Purpose**: Author release-body markdown content conforming to CAP-REL-006-02-01..05 BEFORE `tag_release.py --release-only` runs.
+**Purpose**: Author release-body markdown content conforming to the eight live CAP-REL-006-02 sub-requirements (`-01`,`-02`,`-03`,`-04`,`-05`,`-07`,`-08`,`-09`; `-06` is WITHDRAWN) BEFORE `tag_release.py --release-only` runs.
 
 **When**: AFTER tag cut (Phase 5) AND BEFORE GitHub Release creation.
 
@@ -2419,9 +2419,9 @@ See: `docs/COMMUNICATION_STANDARDS.md` for full template
 
 **Starting point**: copy [`templates/TEMPLATE_RELEASE_BODY.md`](../templates/TEMPLATE_RELEASE_BODY.md) (effective v3.18+; first worked example v3.17.0 refresh 2026-05-10). The template encodes the enhanced structure derived from L941-L944 lessons: lead-with-outcome bullet pattern, trailing `*Traceability:*` IDs, mandatory "What This Release Doesn't Change" section for honest gap recording. Voice requirement: REQ-HOM-Q-001 (no em-dash compounds; majority ≤15-word sentences).
 
-For aget/ canonical: rich body matching CAP-REL-006-02-01..05 — Theme line + What's New section with ≥3 bullets summarizing CHANGELOG Added/Changed + Compatibility section + Sleeping-CAPs Disclosure (if applicable) + resolvable CHANGELOG/AGET_DELTA link.
+For aget/ canonical: rich body matching the eight live sub-requirements — Theme line + What's New with **5-10 scannable items** (list items OR bold-lead paragraphs, each ≤2 rendered lines) summarizing CHANGELOG Added/Changed + Compatibility section + any applicable **registered** disclosure section + resolvable CHANGELOG/AGET_DELTA link + conformant release title.
 
-For 13 templates: slim body matching same schema with ≥3 bullets framework-aligned (each template's CHANGELOG entry is shorter than aget/'s; bullets summarize the template-specific changes per template-CHANGELOG.md `## [X.Y.Z]` section).
+For 13 templates: slim body matching same schema with 5-10 scannable items framework-aligned (each template's CHANGELOG entry is shorter than aget/'s; bullets summarize the template-specific changes per template-CHANGELOG.md `## [X.Y.Z]` section).
 
 Author location (private workspace; NOT committed canonical):
 - `release-notes/v{X.Y.Z}_release_body_aget.md` — rich body
@@ -2828,7 +2828,7 @@ grep -q "Pilot.*Status\|private-supervisor-AGET" \
 python3 aget/verification/validate_release_body.py --version X.Y.Z --all-repos
 ```
 
-Validates: Theme line + What's New ≥3 bullets + Compatibility section + Sleeping-CAPs Disclosure (if applicable) + resolvable CHANGELOG link, across 14 repos.
+Validates all eight live sub-requirements across 14 repos: Theme line + What's New with 5-10 scannable items + Compatibility + registered-name section vocabulary + resolvable CHANGELOG link + body length + core-pair presence + release title. Each live sub-requirement emits a keyed result; an unevaluable check emits UNAVAILABLE rather than being omitted.
 
 **Failure**: BLOCKING — Phase 7 SHALL NOT proceed if any repo fails. Remediation: revise release-body content via `gh release edit --notes-file <revised>` until V-test PASSes.
 

--- a/sops/templates/RELEASE_BODY_TEMPLATE_core.md
+++ b/sops/templates/RELEASE_BODY_TEMPLATE_core.md
@@ -38,10 +38,19 @@ NOT for template-{archetype}-aget release bodies — those use `RELEASE_BODY_TEM
 
 - **{Headline change 1}** — {one-line description with version delta or capability summary}
 - **{Headline change 2}** — {...}
-- **{...}** — typically 5-10 bullets for non-breaking minor; up to 12 for substantive
+- **{...}** — **5-10 scannable items** (CAP-REL-006-02-02, normative bound). A scannable item is
+  a list item OR a bold-lead paragraph; both conformant, may be mixed. Each ≤2 rendered lines.
+  The former "up to 12 for substantive" guidance is WITHDRAWN — it contradicted the spec bound.
 - {Optional: SOP/spec amendments worth surfacing publicly}
 
 ## Sleeping-CAPs Disclosure (CONDITIONAL — include ONLY if release ships SPEC-LANDED-DEFERRED contracts)
+
+<!-- Registered section names only (CAP-REL-006-02-04; `(or equivalent)` withdrawn in spec v1.18.0):
+     What's New | Compatibility | Migration | Sleeping-CAPs Disclosure |
+     What This Release Doesn't Change (alt: Known issues (pre-existing)) | Deferred |
+     Post-tag repairs | Known gaps (alt: Disclosed limitations).
+     An unregistered heading FAILS validation. Core pair (What's New + Compatibility) always required;
+     there is NO fixed total-section count. -->
 
 {1-2 sentence summary of which CAPs are spec-only-deferred, R-DEP-010 grace cite, removal threshold, procedural enforcement note if applicable}
 

--- a/sops/templates/RELEASE_BODY_TEMPLATE_template.md
+++ b/sops/templates/RELEASE_BODY_TEMPLATE_template.md
@@ -173,3 +173,15 @@ echo "✅ L909 PASS"
 ---
 
 *RELEASE_BODY_TEMPLATE_template.md — authored 2026-05-02 to close the core-vs-template release-body distinction gap. v3.16.0 archetype-templates calibration history: 138 (under-floor; original L671 anti-pattern) → 1155 (over-cap; verbatim CHANGELOG paste anti-pattern) → 766 (correct; skeleton 2 norm).*
+
+## Contract bounds (CAP-REL-006-02, spec v1.18.0)
+
+Template bodies obey the same contract as core, at template density:
+
+- `## What's New` carries **5-10 scannable items**, each ≤2 rendered lines. A scannable item is a
+  list item OR a bold-lead paragraph. Do not pad to reach 5 — if a template genuinely received fewer
+  than five distinct changes, use the explicit-notes path rather than fabricating items.
+- Core pair `## What's New` + `## Compatibility` both required; **no fixed total-section count**.
+- Every H2 must be a registered name (CAP-REL-006-02-04). `(or equivalent)` is withdrawn.
+- Release title: `vX.Y.Z - {theme}`, version appearing exactly once (CAP-REL-006-02-09).
+- The inverse-of-core principle is unchanged: a verbose core body MUST NOT inflate templates.

--- a/specs/AGET_RELEASE_SPEC.md
+++ b/specs/AGET_RELEASE_SPEC.md
@@ -1,11 +1,11 @@
 # AGET Release Specification
 
-**Version**: 1.17.1
+**Version**: 1.18.0
 **Status**: Active
 **Category**: Process (Release Management)
 **Format Version**: 1.2
 **Created**: 2026-01-04
-**Updated**: 2026-05-02
+**Updated**: 2026-08-17
 **Author**: aget-framework
 **Location**: `aget/specs/AGET_RELEASE_SPEC.md`
 **Change Origin**: PROJECT_PLAN_v3.2.0 Gate 2.2
@@ -343,16 +343,57 @@ python3 -c "import json; v=json.load(open('.aget/version.json')); print('PASS' i
 | CAP-REL-006-01 | Every tag SHALL have corresponding GitHub Release | User visibility |
 | CAP-REL-006-02 | Release notes SHALL summarize CHANGELOG | Accessibility |
 | CAP-REL-006-02-01 | Release body SHALL include `**Theme**:` line summarizing the cycle's theme/title | Headline accessibility |
-| CAP-REL-006-02-02 | Release body SHALL include `## What's New` section with **5-10 bullet items, each ≤2 lines** summarizing CHANGELOG `### Added` and/or `### Changed` sections | Substantive summarization with precedent-grounded bounds (v3.15: 10 bullets; v3.16: 7 bullets; ≤2-line bullets per precedent compactness; closes "verbose ballooning" anti-pattern surfaced at v3.17 release-day audit) |
+| CAP-REL-006-02-02 | Release body SHALL include a `## What's New` section carrying **5-10 scannable items, each ≤2 rendered lines**, summarizing CHANGELOG `### Added` and/or `### Changed` sections. A **scannable item** is a bounded change summary rendered EITHER as a markdown list item (`-`/`*`) OR as a bold-lead paragraph (`**Lead** — detail`). Both renderings are conformant; MIXING them within one `## What's New` section is conformant. Prose paragraphs without a bold lead are NOT scannable items. | Substantive summarization with precedent-grounded bounds (v3.15: 10 items; v3.16: 7 items; ≤2-line compactness closes the "verbose ballooning" anti-pattern from the v3.17 release-day audit). **Rendering-neutral since v1.18.0**: the bounded-item *invariant* is what the bound was measuring; bullet syntax was incidental. v3.28.0 shipped 16 bounded bold-lead items and failed a bullet-only check — improvement read as regression (L1264). |
 | CAP-REL-006-02-03 | Release body SHALL include `## Compatibility` section stating either "No breaking changes" or referencing BREAKING_CHANGES_v{X.Y}.md | Migration clarity |
-| CAP-REL-006-02-04 | If release ships any SPEC-LANDED-IMPL-DEFERRED capabilities OR sleeping requirements, release body SHALL include `## Sleeping-CAPs Disclosure` (or equivalent) section | Honest spec-truthfulness per ADR-007 |
+| CAP-REL-006-02-04 | A release body SHALL carry one disclosure section for each applicable honesty class, named from the CLOSED set in the table below. `(or equivalent)` is **WITHDRAWN as of v1.18.0** — an unlisted section name is a FAIL, not a variant. Where no class applies, no disclosure section is required. | Honest spec-truthfulness per ADR-007, plus vocabulary-first naming (#800 / L954) applied to the framework's most public artifact. `(or equivalent)` admitted eight unregistered names across the corpus which read as synonyms but are **distinct speech acts**. |
 | CAP-REL-006-02-05 | Release body SHALL reference the canonical CHANGELOG entry with a resolvable link (verified to return HTTP 200 at publication time) | Avoids broken links (closes 17-cycle AGET_DELTA chronic) |
 | ~~CAP-REL-006-02-06~~ | ~~Release body length SHALL be ≥ 30 lines~~ | **WITHDRAWN at authoring time** (CAP-REL-006-02-07 below replaces with precedent-grounded bounds) |
 | CAP-REL-006-02-07 | Release body total length SHALL be **12-25 non-blank lines** (~1500-2500 bytes) for minor releases; **5-15 lines** for patch releases. Range derived from v3.15+v3.16 precedent measurement (v3.15=22 lines/1922 bytes; v3.16=13 lines/1678 bytes). Bodies outside range FAIL the V-test as either too-thin (presence-only) OR too-long (verbose ballooning). | Precedent-grounded bounds (NOT aspirational architecture; per L289 evidence-first design at spec-authoring layer); closes recursive Theme C3 V-test scope-of-validation gap at spec-authoring scope (6th in-cycle recurrence) |
-| CAP-REL-006-02-08 | Release body SHALL contain exactly **3 H2 sections**: What's New + (Sleeping-CAPs Disclosure if applicable / Compatibility) + Compatibility. References (links) MAY be inline with sections; no separate ## References section. | Precedent (v3.15: 3 sections; v3.16: 3 sections); rejects "extra section" verbosity pattern |
+| CAP-REL-006-02-08 | A release body SHALL carry the **core pair** — `## What's New` AND `## Compatibility` — each independently required. It MAY carry `## Migration` and zero or more disclosure sections, every H2 being a registered name per CAP-REL-006-02-04. There is **no fixed total-section count**. References (links) MAY be inline with sections; a separate `## References` section SHALL NOT be used. | **Corpus-derived, re-measured 2026-08-17** over the v3.17.0-v3.31.0 template era (n=18, `gh release view --json body`): the core pair holds at **16/18 (89%)** while exactly-three-H2 holds at only **7/18 (39%)**. The prior "exactly 3" was never precedent-grounded — a clause the majority of its own governed corpus violates is measuring the wrong thing (L742: the specification is at fault). The variation it read as drift lives **entirely in the disclosure sections**, which -04 now governs by name; the prior rule conflated *core sections* with *total sections*. Both remaining failures (v3.24.0, v3.25.0) are genuine missing-core defects the old rule buried among false positives. |
 | CAP-REL-006-02-09 | Release title SHALL be `v{X.Y.Z} - {theme}` (or `v{X.Y.Z} — {theme}` em-dash; precedent allows both). Title SHALL NOT contain `v{X.Y.Z}` more than once. | Precedent (v3.14.1: "v3.14.1 — #979 installer"; v3.15: "v3.15.0 — Two-Level Model"; v3.16: "v3.16.0 - Framework-Discipline Closure"); closes v3.17 duplication anomaly ("v3.17.0 - v3.17.0 — Theme C3..." caught at release-day audit). Either `tag_release.py:create_release()` SHALL detect leading-version-in-description and strip it, OR caller SHALL NOT include version in --description. V-CAP-REL-006-02 enforces via `gh release view --json name` regex match. |
 | CAP-REL-006-03 | Pre-releases SHALL be marked as such | Stability signaling |
-| **V-CAP-REL-006-02** | **paired V-test** | **`aget/verification/validate_release_body.py`** fetches each repo's `gh release view --json body` post-publication AND validates conformance to CAP-REL-006-02-01..06; FAIL on any non-conforming release. Closes 17-cycle chronic gap. |
+| **V-CAP-REL-006-02** | **paired V-test** | **`aget/verification/validate_release_body.py`** fetches each repo's `gh release view --json body` **and `--json name`** post-publication and validates conformance to the **eight live sub-requirements** — `-01`, `-02`, `-03`, `-04`, `-05`, `-07`, `-08`, `-09` (`-06` is WITHDRAWN and is not validated). The validator SHALL emit one keyed result per live sub-requirement; a sub-requirement that cannot be evaluated SHALL emit an explicit `UNAVAILABLE` result and SHALL NOT be silently omitted. FAIL on any non-conforming release. Closes 17-cycle chronic gap. |
+
+**CAP-REL-006-02-04 registered section vocabulary** (normative; referenced by `-04` and `-08`).
+Every H2 in a release body SHALL be a registered name. Names carry a **preferred label** and optional
+**alternate labels** in the SKOS sense — an alternate is the same speech act under an attested name, NOT
+a licence to coin new ones. An unregistered H2 is a FAIL.
+
+*Structural sections*
+
+| Role | Preferred label | Required when |
+|---|---|---|
+| Core | `## What's New` | always (CAP-REL-006-02-02) |
+| Core | `## Compatibility` | always (CAP-REL-006-02-03) |
+| Conditional | `## Migration` | the release ships breaking changes |
+
+*Disclosure sections — one per applicable honesty class*
+
+| Honesty class | Preferred label | Registered alternates | Fires when |
+|---|---|---|---|
+| Deferred capability | `## Sleeping-CAPs Disclosure` | — | any SPEC-LANDED-IMPL-DEFERRED CAP or sleeping requirement ships |
+| Carried debt | `## What This Release Doesn't Change` | `## Known issues (pre-existing)` | known defects exist that this release neither introduced nor fixed |
+| Scope reduction | `## Deferred` | — | planned scope was cut in-cycle |
+| Post-tag amendment | `## Post-tag repairs` | — | release-coupled paths changed after the tag |
+| Ship-time limitation | `## Known gaps` | `## Disclosed limitations` | a limitation is known AT ship time and is not a deferred CAP |
+
+**Derivation (2026-08-17, live `gh release view` census over v3.17.0-v3.31.0, n=18).** This registry is
+corpus-derived, not designed. Seventeen distinct H2 names are attested; the eleven above are registered
+and the remaining six (`Notes`, `Summary`, `Propagation`, `Overview`, `Honest disclosure`,
+`Cycle Discipline Highlight — Honest Defect Acknowledgment`, plus the bare CHANGELOG headings `Added` and
+`Changed`) are not. Under this registry v3.26.0-v3.31.0 — every release of the last six cycles —
+conforms without edit. Earlier non-conforming bodies are dated artifacts, not current failures (L944):
+this clause governs releases published after v1.18.0.
+
+**Two corrections to the staged 2026-07-26 delta, both forced by re-measurement.** That delta proposed a
+closed FOUR-name set and cited v3.28.0's `Disclosed limitations` as the falsifier proving a fifth class
+was owed. **At source today v3.28.0 carries no such section** — its H2s are What's New / Compatibility /
+Migration. The body was rewritten during the 2026-08-16 manager-side remediation, so the delta's corpus
+evidence describes bodies that no longer exist. The fifth class is nonetheless real and is registered
+above, now grounded in v3.31.0's live `Known gaps`. Separately, `## Migration` — carried by three of the
+last four releases and already mandated by `TEMPLATE_RELEASE_BODY.md`'s checklist — is **not a disclosure
+class at all**; it is a conditional structural section, and a closed disclosure set that omitted it would
+have failed v3.28.0, v3.29.0 and v3.30.0 on a category error.
 
 ### CAP-REL-007: Release Documentation
 
@@ -1681,6 +1722,37 @@ Per the two-level model (L742): requirements define principal intent (human leve
 ---
 
 ## Changelog
+
+### v1.18.0 (2026-08-17)
+
+Release-body contract alignment — spec, three authoring templates, SOP, and canonical validator made
+to state one executable contract. Tracking `gh#2004`.
+
+- **CAP-REL-006-02-02 is rendering-neutral.** "5-10 bullet items" becomes "5-10 **scannable items**",
+  where an item is a list item OR a bold-lead paragraph, each ≤2 rendered lines. Both renderings are
+  conformant and may be mixed. The bounded-item invariant is what the bound always measured; bullet
+  syntax was incidental. v3.28.0 shipped 16 bounded bold-lead items and failed a bullet-only check —
+  improvement read as regression (L1264).
+- **CAP-REL-006-02-04 closes the `(or equivalent)` escape hatch** with a registered section vocabulary
+  carrying SKOS preferred/alternate labels. Corpus-derived from a live census over v3.17.0-v3.31.0
+  (n=18, 17 distinct H2 names attested). Structural sections (core pair + conditional `## Migration`)
+  are separated from disclosure sections; five honesty classes are registered. An unregistered heading
+  is a FAIL, not a variant.
+- **CAP-REL-006-02-08 drops the fixed section count.** "Exactly 3 H2 sections" held for only 7/18
+  template-era bodies and was never precedent-grounded; the core pair (`What's New` AND `Compatibility`)
+  holds at 16/18. The prior rule conflated core sections with total sections and manufactured false
+  failures, while the two genuine defects (v3.24.0, v3.25.0) stayed buried among them. Per L742 the
+  specification was at fault, not the corpus.
+- **V-CAP-REL-006-02 states its true coverage.** It claimed `01..06`; the live set is
+  `-01,-02,-03,-04,-05,-07,-08,-09` (`-06` is WITHDRAWN). The validator now emits one keyed result per
+  live sub-requirement, and a check that cannot be evaluated emits `UNAVAILABLE` rather than being
+  omitted — the shipped validator silently dropped `-09`, so seven green checks read as a complete pass
+  (L671).
+- **CAP-REL-006-02-09 is enforced for the first time.** Title validation existed as a comment claiming
+  `main()` would populate it; `main()` never did.
+
+Conformance effect: v3.26.0-v3.31.0 conform without edit. Earlier bodies remain dated artifacts under
+L944 — this clause governs releases published after v1.18.0.
 
 ### v1.16.1 (2026-05-02)
 

--- a/templates/TEMPLATE_RELEASE_BODY.md
+++ b/templates/TEMPLATE_RELEASE_BODY.md
@@ -18,7 +18,13 @@ TEMPLATE INSTRUCTIONS:
 ## What's New
 
 <!--
-Bullet-form. Each bullet:
+5-10 SCANNABLE ITEMS, each at most 2 rendered lines (CAP-REL-006-02-02).
+A scannable item is EITHER a list item (- or *) OR a bold-lead paragraph
+(**Lead** — detail). Both renderings are conformant and may be mixed; the
+bounded-item invariant is what the count measures, not bullet syntax.
+A prose paragraph with no bold lead is NOT a scannable item.
+
+Each item:
   1. Lead with plain-language outcome in **bold** (≤15 words)
   2. Follow with 1-2 sentences of context, technical detail, theoretical basis
   3. Optional trailing `*Traceability: T-IDs, gh#NNN*` line for internal references
@@ -99,10 +105,18 @@ Before publishing a release body authored from this template:
 
 - [ ] Theme line present and starts with `**Theme**:` (case-sensitive)
 - [ ] For: reader line present — names the intended reader (lifts D1 Intent Clarity; advisory, not a hard validator marker)
-- [ ] What's New section has ≥1 bullet
-- [ ] Compatibility section present
+- [ ] What's New section has **5-10 scannable items**, each ≤2 rendered lines (CAP-REL-006-02-02)
+- [ ] Compatibility section present — the core pair is What's New **and** Compatibility, both required
+- [ ] Every H2 is a **registered** section name (CAP-REL-006-02-04). `(or equivalent)` was withdrawn in
+      spec v1.18.0: an unregistered heading is a FAIL, not a variant. Registered names are
+      `What's New`, `Compatibility`, `Migration`, `Sleeping-CAPs Disclosure`,
+      `What This Release Doesn't Change` (alt: `Known issues (pre-existing)`), `Deferred`,
+      `Post-tag repairs`, `Known gaps` (alt: `Disclosed limitations`)
+- [ ] No fixed total-section count — carry the core pair plus whatever registered sections apply
 - [ ] If breaking changes declared, Migration section present
 - [ ] If sleeping CAPs exist (newly added or inherited), Sleeping-CAPs Disclosure present
+- [ ] Release **title** is `vX.Y.Z - {theme}` or `vX.Y.Z — {theme}`, with the version appearing
+      exactly once (CAP-REL-006-02-09)
 - [ ] Voice check: <20% sentences exceed 15 words; no em-dash compound clauses leading bullets
 - [ ] Evidence check: each capability claim has artifact link OR `(experimental)`/`(planned)` qualifier
 - [ ] Internal-link integrity: all hyperlinks resolve (run `post_release_validation.py` post-publish)

--- a/tests/test_validate_release_body.py
+++ b/tests/test_validate_release_body.py
@@ -86,15 +86,17 @@ Skill definitions carried forward without edit across the upgrade.
 # --- SC-2: both renderings are conformant -----------------------------------------------
 
 def test_bullet_form_passes():
+    """CAP-REL-006-02-02 — both-polarity contract test."""
     assert check(run(BULLET_BODY), "02").startswith("PASS")
 
 
 def test_bold_lead_form_passes():
-    """The v3.28.0 regression: 16 bounded bold-lead items failed a bullet-only check (L1264)."""
+    """CAP-REL-006-02-02: The v3.28.0 regression: 16 bounded bold-lead items failed a bullet-only check (L1264)."""
     assert check(run(BOLD_LEAD_BODY), "02").startswith("PASS")
 
 
 def test_mixed_rendering_passes():
+    """CAP-REL-006-02-02 — both-polarity contract test."""
     mixed = BULLET_BODY.replace(
         "- Fifth delivered capability landed this cycle.",
         "**Fifth capability** — landed this cycle.",
@@ -103,6 +105,7 @@ def test_mixed_rendering_passes():
 
 
 def test_prose_paragraph_is_not_a_scannable_item():
+    """CAP-REL-006-02-02 — both-polarity contract test."""
     prose = BULLET_BODY.replace(
         "- First delivered capability landed this cycle.",
         "This release delivers a capability, described here in prose without a bold lead.",
@@ -112,6 +115,7 @@ def test_prose_paragraph_is_not_a_scannable_item():
 
 @pytest.mark.parametrize("count,expect", [(4, "FAIL"), (5, "PASS"), (10, "PASS"), (11, "FAIL")])
 def test_item_count_bounds_both_polarities(count, expect):
+    """CAP-REL-006-02-02 — both-polarity contract test."""
     items = "\n".join(f"- Delivered capability number {i}." for i in range(count))
     body = f"""**Theme**: Bounds
 
@@ -130,6 +134,7 @@ Skill definitions carry forward without edit.
 
 
 def test_overlong_item_fails():
+    """CAP-REL-006-02-02 — both-polarity contract test."""
     body = BULLET_BODY.replace(
         "- First delivered capability landed this cycle.",
         "- First capability\n  continued onto a second line\n  and then a third line.",
@@ -140,27 +145,31 @@ def test_overlong_item_fails():
 # --- SC-3: core pair required, no fixed total-section count -----------------------------
 
 def test_core_pair_present_passes():
+    """CAP-REL-006-02-08 — both-polarity contract test."""
     assert check(run(BULLET_BODY), "08").startswith("PASS")
 
 
 def test_two_sections_passes_no_fixed_count():
-    """The old rule demanded exactly 3 H2s; 2 is conformant when both are core (v3.26.0)."""
+    """CAP-REL-006-02-08: The old rule demanded exactly 3 H2s; 2 is conformant when both are core (v3.26.0)."""
     result = run(BULLET_BODY)
     assert check(result, "08").startswith("PASS")
 
 
 def test_four_sections_passes_no_fixed_count():
+    """CAP-REL-006-02-08 — both-polarity contract test."""
     body = BULLET_BODY + "\n## Migration\n\nFollow the upgrade note.\n\n## Known gaps\n\nOne gap remains.\n"
     assert check(run(body), "08").startswith("PASS")
 
 
 def test_missing_whats_new_fails():
+    """CAP-REL-006-02-08 — both-polarity contract test."""
     body = BULLET_BODY.replace("## What's New", "## Overview")
     assert "what's new" in check(run(body), "08").lower()
     assert check(run(body), "08").startswith("FAIL")
 
 
 def test_missing_compatibility_fails():
+    """CAP-REL-006-02-08 — both-polarity contract test."""
     body = BULLET_BODY.replace("## Compatibility", "## Notes").replace("No breaking changes. ", "")
     assert check(run(body), "08").startswith("FAIL")
 
@@ -168,22 +177,25 @@ def test_missing_compatibility_fails():
 # --- -04: registered vocabulary ---------------------------------------------------------
 
 def test_registered_disclosure_passes():
+    """CAP-REL-006-02-04 — both-polarity contract test."""
     body = BULLET_BODY + "\n## Known gaps\n\nOne limitation ships with this release.\n"
     assert check(run(body), "04").startswith("PASS")
 
 
 def test_registered_alternate_label_passes():
+    """CAP-REL-006-02-04 — both-polarity contract test."""
     body = BULLET_BODY + "\n## Disclosed limitations\n\nOne limitation ships.\n"
     assert check(run(body), "04").startswith("PASS")
 
 
 def test_unregistered_section_name_fails():
-    """'(or equivalent)' was withdrawn in v1.18.0 — an unlisted name is a FAIL, not a variant."""
+    """CAP-REL-006-02-04: '(or equivalent)' was withdrawn in v1.18.0 — an unlisted name is a FAIL, not a variant."""
     body = BULLET_BODY + "\n## Honest disclosure\n\nSomething undisclosed.\n"
     assert check(run(body), "04").startswith("FAIL")
 
 
 def test_sleeping_caps_mentioned_without_section_fails():
+    """CAP-REL-006-02-04 — both-polarity contract test."""
     body = BULLET_BODY.replace(
         "- First delivered capability landed this cycle.",
         "- One SPEC-LANDED-IMPL-DEFERRED capability ships asleep.",
@@ -192,7 +204,7 @@ def test_sleeping_caps_mentioned_without_section_fails():
 
 
 def test_migration_is_structural_not_disclosure():
-    """v3.28.0-v3.30.0 carry ## Migration; a disclosure-only registry would fail all three."""
+    """CAP-REL-006-02-04: v3.28.0-v3.30.0 carry ## Migration; a disclosure-only registry would fail all three."""
     body = BULLET_BODY + "\n## Migration\n\nFollow the upgrade note.\n"
     assert check(run(body), "04").startswith("PASS")
     assert check(run(body), "08").startswith("PASS")
@@ -201,26 +213,29 @@ def test_migration_is_structural_not_disclosure():
 # --- -09: title, both polarities --------------------------------------------------------
 
 def test_title_conformant_passes():
+    """CAP-REL-006-02-09 — both-polarity contract test."""
     assert check(run(BULLET_BODY, title="v3.31.0 — Ship What Was Already Built"), "09").startswith("PASS")
 
 
 def test_title_hyphen_form_passes():
+    """CAP-REL-006-02-09 — both-polarity contract test."""
     assert check(run(BULLET_BODY, title="v3.31.0 - Ship What Was Already Built"), "09").startswith("PASS")
 
 
 def test_title_duplicated_version_fails():
-    """The v3.17 anomaly: 'v3.17.0 - v3.17.0 — Theme C3...'."""
+    """CAP-REL-006-02-09: The v3.17 anomaly: 'v3.17.0 - v3.17.0 — Theme C3...'."""
     assert check(run(BULLET_BODY, title="v3.31.0 - v3.31.0 — Ship It"), "09").startswith("FAIL")
 
 
 def test_title_missing_version_fails():
+    """CAP-REL-006-02-09 — both-polarity contract test."""
     assert check(run(BULLET_BODY, title="Ship What Was Already Built"), "09").startswith("FAIL")
 
 
 # --- SC-1: coverage — the check that would have caught the -09 stub ----------------------
 
 def test_all_eight_live_subrequirements_emit_a_result():
-    """
+    """V-CAP-REL-006-02: 
     The shipped validator emitted seven checks and silently omitted -09, so a reader counting
     green checks saw PASS with no signal a requirement went unevaluated (L671).
     """
@@ -231,11 +246,12 @@ def test_all_eight_live_subrequirements_emit_a_result():
 
 
 def test_withdrawn_06_is_not_emitted():
+    """CAP-REL-006-02-06 — both-polarity contract test."""
     assert not any("-06" in k for k in run(BULLET_BODY)["checks"])
 
 
 def test_absent_title_emits_unavailable_not_omission():
-    """An unevaluable check must announce itself rather than vanish."""
+    """CAP-REL-006-02-09: An unevaluable check must announce itself rather than vanish."""
     result = run(BULLET_BODY, title=None)
     assert check(result, "09").startswith("UNAVAILABLE")
     assert len(result["checks"]) == 8
@@ -245,14 +261,17 @@ def test_absent_title_emits_unavailable_not_omission():
 # --- -05 link resolution, both polarities -----------------------------------------------
 
 def test_link_resolves_passes():
+    """CAP-REL-006-02-05 — both-polarity contract test."""
     assert check(run(BULLET_BODY, resolver=always_resolves), "05").startswith("PASS")
 
 
 def test_link_unresolvable_fails():
+    """CAP-REL-006-02-05 — both-polarity contract test."""
     assert check(run(BULLET_BODY, resolver=never_resolves), "05").startswith("FAIL")
 
 
 def test_no_link_fails():
+    """CAP-REL-006-02-05 — both-polarity contract test."""
     body = BULLET_BODY.replace(f"[CHANGELOG]({CHANGELOG})", "the changelog")
     assert check(run(body), "05").startswith("FAIL")
 
@@ -260,15 +279,18 @@ def test_no_link_fails():
 # --- -01 / -07 --------------------------------------------------------------------------
 
 def test_theme_present_passes():
+    """CAP-REL-006-02-01 — both-polarity contract test."""
     assert check(run(BULLET_BODY), "01").startswith("PASS")
 
 
 def test_theme_absent_fails():
+    """CAP-REL-006-02-01 — both-polarity contract test."""
     assert check(run(BULLET_BODY.replace("**Theme**: Ship What Was Already Built", "Ship it")), "01").startswith("FAIL")
 
 
 @pytest.mark.parametrize("filler,expect", [(0, "FAIL"), (8, "PASS")])
 def test_length_bounds_both_polarities(filler, expect):
+    """CAP-REL-006-02-07 — both-polarity contract test."""
     body = f"""**Theme**: Bounds
 
 ## What's New
@@ -284,3 +306,60 @@ def test_length_bounds_both_polarities(filler, expect):
 No breaking changes. See [CHANGELOG]({CHANGELOG}).
 """ + "".join(f"Additional compatibility note number {i}.\n" for i in range(filler))
     assert check(run(body), "07").startswith(expect)
+
+
+# --- audit 2026-08-17: mutation testing left three checks unexercised --------------------
+# 15 mutants, 12 killed. These close the three that survived.
+
+def test_overall_is_FAIL_when_any_check_fails():
+    """
+    V-CAP-REL-006-02: the aggregate verdict must go FAIL when any sub-check fails.
+
+    `overall` is what main() converts into the process exit code, and it was asserted
+    exactly once in this suite — on the UNAVAILABLE branch. Deleting the FAIL aggregation
+    left all 33 tests green: the rare path was covered and the common one was not.
+    """
+    body = BULLET_BODY.replace("**Theme**: Ship What Was Already Built", "no theme line here")
+    result = run(body)
+    assert check(result, "01").startswith("FAIL")
+    assert result["overall"] == "FAIL", "a failing sub-check must drive overall to FAIL"
+
+
+def test_compatibility_check_itself_fails_not_only_the_core_pair():
+    """
+    CAP-REL-006-02-03: -03 must fail on its own predicate, not via its -08 sibling.
+
+    test_missing_compatibility_fails asserts on "08", so -03 could be made
+    unconditionally PASS with the suite still green.
+    """
+    body = BULLET_BODY.replace("## Compatibility", "## Notes").replace("No breaking changes. ", "")
+    assert check(run(body), "03").startswith("FAIL")
+
+
+def test_compat_prose_without_h2_separates_03_from_08():
+    """
+    CAP-REL-006-02-03 vs -08: the two predicates genuinely diverge and must be seen to.
+
+    -03 accepts a bare "No breaking changes" statement anywhere in the body; -08 requires
+    the literal H2. A body carrying the prose but not the heading splits them.
+    """
+    body = BULLET_BODY.replace("## Compatibility\n\n", "")
+    assert check(run(body), "03").startswith("PASS"), "-03 accepts the prose form"
+    assert check(run(body), "08").startswith("FAIL"), "-08 still requires the H2"
+
+
+@pytest.mark.parametrize("title", [
+    "v3.31.0: Ship It",           # colon, not a dash
+    "Release v3.31.0 — Ship It",  # version not in leading position
+    "v3.31.0",                    # no theme at all
+    "v3.31.0—Ship It",            # em-dash without surrounding space
+])
+def test_title_wrong_shape_fails(title):
+    """
+    CAP-REL-006-02-09: the shape clause must be exercised, not only the occurrence clauses.
+
+    Both prior negative title tests trip the occurrence checks (missing / duplicated) before
+    reaching the shape regex, so the regex could be deleted with the suite still green.
+    Each title here contains the version exactly once and is still non-conformant.
+    """
+    assert check(run(BULLET_BODY, title=title), "09").startswith("FAIL")

--- a/tests/test_validate_release_body.py
+++ b/tests/test_validate_release_body.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Both-polarity contract tests for V-CAP-REL-006-02 (AGET_RELEASE_SPEC v1.18.0).
+
+Every requirement is asserted in BOTH directions: a conformant fixture must PASS and a
+targeted-defect fixture must FAIL *for the intended reason*. A test that only ever asserts
+the green path cannot detect a check that stopped firing (L671).
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_VALIDATOR = pathlib.Path(__file__).resolve().parents[1] / "verification" / "validate_release_body.py"
+_spec = importlib.util.spec_from_file_location("validate_release_body", _VALIDATOR)
+vrb = importlib.util.module_from_spec(_spec)
+sys.modules["validate_release_body"] = vrb
+_spec.loader.exec_module(vrb)
+
+
+def never_resolves(_url):
+    return False
+
+
+def always_resolves(_url):
+    return True
+
+
+def run(body, title="v3.31.0 — Ship What Was Already Built", resolver=always_resolves):
+    return vrb.validate_body("aget-framework/aget", "3.31.0", body, title=title,
+                             link_resolver=resolver)
+
+
+def check(result, sub):
+    """Return the single check value whose key carries this sub-requirement number."""
+    matches = [v for k, v in result["checks"].items() if k.startswith(f"CAP-REL-006-02-{sub}")]
+    assert len(matches) == 1, f"expected exactly one check for -{sub}, got {matches}"
+    return matches[0]
+
+
+CHANGELOG = "https://github.com/aget-framework/aget/blob/main/CHANGELOG.md"
+
+BULLET_BODY = f"""**Theme**: Ship What Was Already Built
+
+## What's New
+
+- First delivered capability landed this cycle.
+- Second delivered capability landed this cycle.
+- Third delivered capability landed this cycle.
+- Fourth delivered capability landed this cycle.
+- Fifth delivered capability landed this cycle.
+
+## Compatibility
+
+No breaking changes. See [CHANGELOG]({CHANGELOG}) for full detail.
+Downstream agents upgrade in place with no migration step required.
+Existing configuration files are read unchanged by this release.
+Skill definitions carried forward without edit across the upgrade.
+"""
+
+BOLD_LEAD_BODY = f"""**Theme**: Ship What Was Already Built
+
+## What's New
+
+**Contract alignment** — the release-body contract now matches its corpus.
+
+**Validator coverage** — every live sub-requirement emits a keyed result.
+
+**Title validation** — release titles are checked, not merely specified.
+
+**Registered vocabulary** — section names come from a closed registry.
+
+**Scannable grammar** — bullets and bold leads are both conformant.
+
+## Compatibility
+
+No breaking changes. See [CHANGELOG]({CHANGELOG}) for full detail.
+Downstream agents upgrade in place with no migration step required.
+Existing configuration files are read unchanged by this release.
+Skill definitions carried forward without edit across the upgrade.
+"""
+
+
+# --- SC-2: both renderings are conformant -----------------------------------------------
+
+def test_bullet_form_passes():
+    assert check(run(BULLET_BODY), "02").startswith("PASS")
+
+
+def test_bold_lead_form_passes():
+    """The v3.28.0 regression: 16 bounded bold-lead items failed a bullet-only check (L1264)."""
+    assert check(run(BOLD_LEAD_BODY), "02").startswith("PASS")
+
+
+def test_mixed_rendering_passes():
+    mixed = BULLET_BODY.replace(
+        "- Fifth delivered capability landed this cycle.",
+        "**Fifth capability** — landed this cycle.",
+    )
+    assert check(run(mixed), "02").startswith("PASS")
+
+
+def test_prose_paragraph_is_not_a_scannable_item():
+    prose = BULLET_BODY.replace(
+        "- First delivered capability landed this cycle.",
+        "This release delivers a capability, described here in prose without a bold lead.",
+    )
+    assert check(run(prose), "02").startswith("FAIL")
+
+
+@pytest.mark.parametrize("count,expect", [(4, "FAIL"), (5, "PASS"), (10, "PASS"), (11, "FAIL")])
+def test_item_count_bounds_both_polarities(count, expect):
+    items = "\n".join(f"- Delivered capability number {i}." for i in range(count))
+    body = f"""**Theme**: Bounds
+
+## What's New
+
+{items}
+
+## Compatibility
+
+No breaking changes. See [CHANGELOG]({CHANGELOG}).
+Downstream agents upgrade in place with no migration step.
+Existing configuration files are read unchanged.
+Skill definitions carry forward without edit.
+"""
+    assert check(run(body), "02").startswith(expect)
+
+
+def test_overlong_item_fails():
+    body = BULLET_BODY.replace(
+        "- First delivered capability landed this cycle.",
+        "- First capability\n  continued onto a second line\n  and then a third line.",
+    )
+    assert check(run(body), "02").startswith("FAIL")
+
+
+# --- SC-3: core pair required, no fixed total-section count -----------------------------
+
+def test_core_pair_present_passes():
+    assert check(run(BULLET_BODY), "08").startswith("PASS")
+
+
+def test_two_sections_passes_no_fixed_count():
+    """The old rule demanded exactly 3 H2s; 2 is conformant when both are core (v3.26.0)."""
+    result = run(BULLET_BODY)
+    assert check(result, "08").startswith("PASS")
+
+
+def test_four_sections_passes_no_fixed_count():
+    body = BULLET_BODY + "\n## Migration\n\nFollow the upgrade note.\n\n## Known gaps\n\nOne gap remains.\n"
+    assert check(run(body), "08").startswith("PASS")
+
+
+def test_missing_whats_new_fails():
+    body = BULLET_BODY.replace("## What's New", "## Overview")
+    assert "what's new" in check(run(body), "08").lower()
+    assert check(run(body), "08").startswith("FAIL")
+
+
+def test_missing_compatibility_fails():
+    body = BULLET_BODY.replace("## Compatibility", "## Notes").replace("No breaking changes. ", "")
+    assert check(run(body), "08").startswith("FAIL")
+
+
+# --- -04: registered vocabulary ---------------------------------------------------------
+
+def test_registered_disclosure_passes():
+    body = BULLET_BODY + "\n## Known gaps\n\nOne limitation ships with this release.\n"
+    assert check(run(body), "04").startswith("PASS")
+
+
+def test_registered_alternate_label_passes():
+    body = BULLET_BODY + "\n## Disclosed limitations\n\nOne limitation ships.\n"
+    assert check(run(body), "04").startswith("PASS")
+
+
+def test_unregistered_section_name_fails():
+    """'(or equivalent)' was withdrawn in v1.18.0 — an unlisted name is a FAIL, not a variant."""
+    body = BULLET_BODY + "\n## Honest disclosure\n\nSomething undisclosed.\n"
+    assert check(run(body), "04").startswith("FAIL")
+
+
+def test_sleeping_caps_mentioned_without_section_fails():
+    body = BULLET_BODY.replace(
+        "- First delivered capability landed this cycle.",
+        "- One SPEC-LANDED-IMPL-DEFERRED capability ships asleep.",
+    )
+    assert check(run(body), "04").startswith("FAIL")
+
+
+def test_migration_is_structural_not_disclosure():
+    """v3.28.0-v3.30.0 carry ## Migration; a disclosure-only registry would fail all three."""
+    body = BULLET_BODY + "\n## Migration\n\nFollow the upgrade note.\n"
+    assert check(run(body), "04").startswith("PASS")
+    assert check(run(body), "08").startswith("PASS")
+
+
+# --- -09: title, both polarities --------------------------------------------------------
+
+def test_title_conformant_passes():
+    assert check(run(BULLET_BODY, title="v3.31.0 — Ship What Was Already Built"), "09").startswith("PASS")
+
+
+def test_title_hyphen_form_passes():
+    assert check(run(BULLET_BODY, title="v3.31.0 - Ship What Was Already Built"), "09").startswith("PASS")
+
+
+def test_title_duplicated_version_fails():
+    """The v3.17 anomaly: 'v3.17.0 - v3.17.0 — Theme C3...'."""
+    assert check(run(BULLET_BODY, title="v3.31.0 - v3.31.0 — Ship It"), "09").startswith("FAIL")
+
+
+def test_title_missing_version_fails():
+    assert check(run(BULLET_BODY, title="Ship What Was Already Built"), "09").startswith("FAIL")
+
+
+# --- SC-1: coverage — the check that would have caught the -09 stub ----------------------
+
+def test_all_eight_live_subrequirements_emit_a_result():
+    """
+    The shipped validator emitted seven checks and silently omitted -09, so a reader counting
+    green checks saw PASS with no signal a requirement went unevaluated (L671).
+    """
+    result = run(BULLET_BODY)
+    emitted = {k.split("_")[0].rsplit("-", 1)[1] for k in result["checks"]}
+    assert emitted == set(vrb.LIVE_SUBREQUIREMENTS), f"missing: {set(vrb.LIVE_SUBREQUIREMENTS) - emitted}"
+    assert len(result["checks"]) == 8
+
+
+def test_withdrawn_06_is_not_emitted():
+    assert not any("-06" in k for k in run(BULLET_BODY)["checks"])
+
+
+def test_absent_title_emits_unavailable_not_omission():
+    """An unevaluable check must announce itself rather than vanish."""
+    result = run(BULLET_BODY, title=None)
+    assert check(result, "09").startswith("UNAVAILABLE")
+    assert len(result["checks"]) == 8
+    assert result["overall"] == "UNAVAILABLE"
+
+
+# --- -05 link resolution, both polarities -----------------------------------------------
+
+def test_link_resolves_passes():
+    assert check(run(BULLET_BODY, resolver=always_resolves), "05").startswith("PASS")
+
+
+def test_link_unresolvable_fails():
+    assert check(run(BULLET_BODY, resolver=never_resolves), "05").startswith("FAIL")
+
+
+def test_no_link_fails():
+    body = BULLET_BODY.replace(f"[CHANGELOG]({CHANGELOG})", "the changelog")
+    assert check(run(body), "05").startswith("FAIL")
+
+
+# --- -01 / -07 --------------------------------------------------------------------------
+
+def test_theme_present_passes():
+    assert check(run(BULLET_BODY), "01").startswith("PASS")
+
+
+def test_theme_absent_fails():
+    assert check(run(BULLET_BODY.replace("**Theme**: Ship What Was Already Built", "Ship it")), "01").startswith("FAIL")
+
+
+@pytest.mark.parametrize("filler,expect", [(0, "FAIL"), (8, "PASS")])
+def test_length_bounds_both_polarities(filler, expect):
+    body = f"""**Theme**: Bounds
+
+## What's New
+
+- One.
+- Two.
+- Three.
+- Four.
+- Five.
+
+## Compatibility
+
+No breaking changes. See [CHANGELOG]({CHANGELOG}).
+""" + "".join(f"Additional compatibility note number {i}.\n" for i in range(filler))
+    assert check(run(body), "07").startswith(expect)

--- a/verification/validate_release_body.py
+++ b/verification/validate_release_body.py
@@ -1,14 +1,23 @@
 #!/usr/bin/env python3
 """
-V-CAP-REL-006-02: Validate GitHub Release body conforms to CAP-REL-006-02-01..06.
+V-CAP-REL-006-02: Validate a GitHub Release against the eight live CAP-REL-006-02 sub-requirements.
 
-Implements:
+Implements (per AGET_RELEASE_SPEC v1.18.0):
 - CAP-REL-006-02-01: Theme line present
-- CAP-REL-006-02-02: What's New section with ≥3 bullets
+- CAP-REL-006-02-02: What's New with 5-10 scannable items, each <=2 rendered lines
+                     (a scannable item is a list item OR a bold-lead paragraph)
 - CAP-REL-006-02-03: Compatibility section
-- CAP-REL-006-02-04: Sleeping-CAPs Disclosure (if applicable)
+- CAP-REL-006-02-04: every H2 is a registered name; required disclosure section per applicable class
 - CAP-REL-006-02-05: CHANGELOG link resolves (HTTP 200)
-- CAP-REL-006-02-06: Body length ≥ 30 lines
+- CAP-REL-006-02-07: body length 12-25 non-blank lines
+- CAP-REL-006-02-08: core pair present (What's New AND Compatibility); no fixed total-section count
+- CAP-REL-006-02-09: release title format
+
+CAP-REL-006-02-06 is WITHDRAWN and is deliberately not validated.
+
+Every live sub-requirement emits exactly one keyed result. A check that cannot be evaluated emits
+UNAVAILABLE and names what was missing -- it is never silently omitted, because a consumer counting
+green checks cannot distinguish an absent check from a passing one.
 
 Usage:
     python3 validate_release_body.py --version 3.17.0 [--repo aget-framework/aget] [--strict] [--json]
@@ -16,7 +25,7 @@ Usage:
 
 Exit codes:
     0 = all PASS
-    1 = any FAIL
+    1 = any FAIL or UNAVAILABLE
     2 = validator error (e.g., gh CLI unavailable)
 """
 
@@ -45,16 +54,70 @@ ALL_REPOS = [
     "aget-framework/template-worker-aget",
 ]
 
+# CAP-REL-006-02-04 registered section vocabulary, corpus-derived 2026-08-17 over v3.17.0-v3.31.0.
+# Keys are normalized labels; values are the honesty/structural class.
+CORE_SECTIONS = {
+    "what's new": "core",
+    "compatibility": "core",
+}
+CONDITIONAL_STRUCTURAL = {
+    "migration": "migration",
+}
+DISCLOSURE_SECTIONS = {
+    # preferred label            class
+    "sleeping-caps disclosure": "deferred_capability",
+    "what this release doesn't change": "carried_debt",
+    "known issues (pre-existing)": "carried_debt",          # registered alternate
+    "deferred": "scope_reduction",
+    "post-tag repairs": "post_tag_amendment",
+    "known gaps": "ship_time_limitation",
+    "disclosed limitations": "ship_time_limitation",        # registered alternate
+}
+REGISTERED_SECTIONS = {**CORE_SECTIONS, **CONDITIONAL_STRUCTURAL, **DISCLOSURE_SECTIONS}
 
-def fetch_release_body(repo: str, version: str) -> str:
-    """Fetch release body via gh CLI."""
+LIVE_SUBREQUIREMENTS = ["01", "02", "03", "04", "05", "07", "08", "09"]
+
+
+def normalize_heading(text: str) -> str:
+    """Normalize an H2 label for registry lookup: case, whitespace, and apostrophe variants."""
+    t = text.strip().lower()
+    t = t.replace("’", "'").replace("‘", "'")
+    t = re.sub(r"\s+", " ", t)
+    return t
+
+
+def extract_h2_labels(body: str) -> list:
+    """Return normalized H2 labels in document order."""
+    return [normalize_heading(m) for m in re.findall(r"^##\s+(.+?)\s*$", body, re.MULTILINE)]
+
+
+def extract_scannable_items(section_text: str) -> list:
+    """
+    Return each scannable item's text.
+
+    A scannable item is a bounded change summary rendered EITHER as a markdown list item
+    (- or *) OR as a bold-lead paragraph (**Lead** - detail). Both are conformant and may be
+    mixed; the bounded-item invariant is what the count was ever measuring, not bullet syntax.
+    """
+    item_start = r"(?:^[ \t]*[-*][ \t]+|^[ \t]*\*\*)"
+    pattern = rf"{item_start}(.+?)(?=\n[ \t]*[-*][ \t]+|\n[ \t]*\*\*|\Z)"
+    return re.findall(pattern, section_text, re.MULTILINE | re.DOTALL)
+
+
+def rendered_line_count(item: str) -> int:
+    """Non-blank rendered lines occupied by one item."""
+    return len([ln for ln in item.strip().split("\n") if ln.strip()])
+
+
+def fetch_release_field(repo: str, version: str, field: str) -> str:
+    """Fetch a single field of a release via gh CLI."""
     tag = f"v{version}"
     result = subprocess.run(
-        ["gh", "release", "view", tag, "--repo", repo, "--json", "body", "-q", ".body"],
+        ["gh", "release", "view", tag, "--repo", repo, "--json", field, "-q", f".{field}"],
         capture_output=True, text=True
     )
     if result.returncode != 0:
-        raise RuntimeError(f"gh release view failed for {repo} {tag}: {result.stderr}")
+        raise RuntimeError(f"gh release view --json {field} failed for {repo} {tag}: {result.stderr}")
     return result.stdout.strip()
 
 
@@ -67,89 +130,146 @@ def url_resolves(url: str, timeout: int = 10) -> bool:
         return False
 
 
-def validate_body(repo: str, version: str, body: str) -> dict:
-    """Run all CAP-REL-006-02-NN sub-requirement checks."""
+def validate_body(repo, version, body, title=None, link_resolver=url_resolves):
+    """
+    Run every live CAP-REL-006-02-NN check.
+
+    title=None means the caller could not supply a title; -09 then emits UNAVAILABLE rather than
+    being omitted. link_resolver is injectable so tests need no network.
+    """
     results = {"repo": repo, "version": version, "checks": {}, "overall": "PASS"}
+    checks = results["checks"]
+    h2_labels = extract_h2_labels(body)
 
-    # CAP-REL-006-02-01: Theme line
-    has_theme = bool(re.search(r'\*\*Theme\*\*:', body))
-    results["checks"]["CAP-REL-006-02-01_theme"] = "PASS" if has_theme else "FAIL"
+    # -01: Theme line
+    checks["CAP-REL-006-02-01_theme"] = (
+        "PASS" if re.search(r"\*\*Theme\*\*:", body) else "FAIL (no **Theme**: line)"
+    )
 
-    # CAP-REL-006-02-02: What's New section with 5-10 bullets, each ≤2 lines (precedent-grounded)
-    whats_new_section = re.search(r'##\s+What\'s New\s*\n((?:.|\n)+?)(?=\n##\s|\Z)', body, re.IGNORECASE)
-    bullets = []
-    if whats_new_section:
-        # Extract each bullet's full content (until next bullet or section end)
-        section_text = whats_new_section.group(1)
-        bullet_blocks = re.findall(r'^\s*[-*]\s+(.+?)(?=\n\s*[-*]\s|\Z)', section_text, re.MULTILINE | re.DOTALL)
-        bullets = bullet_blocks
-    bullet_count = len(bullets)
-    bullets_under_2_lines = all(b.count('\n') <= 1 for b in bullets) if bullets else False
-    if 5 <= bullet_count <= 10 and bullets_under_2_lines:
-        results["checks"]["CAP-REL-006-02-02_whats_new"] = "PASS"
-    elif bullet_count < 5:
-        results["checks"]["CAP-REL-006-02-02_whats_new"] = f"FAIL (found {bullet_count} bullets; need 5-10)"
-    elif bullet_count > 10:
-        results["checks"]["CAP-REL-006-02-02_whats_new"] = f"FAIL (found {bullet_count} bullets; need 5-10 — too verbose)"
+    # -02: What's New with 5-10 scannable items, each <=2 rendered lines
+    section = re.search(r"##\s+What's New\s*\n((?:.|\n)+?)(?=\n##\s|\Z)", body, re.IGNORECASE)
+    if not section:
+        checks["CAP-REL-006-02-02_whats_new"] = "FAIL (no ## What's New section)"
     else:
-        long_bullets = sum(1 for b in bullets if b.count('\n') > 1)
-        results["checks"]["CAP-REL-006-02-02_whats_new"] = f"FAIL ({bullet_count} bullets but {long_bullets} exceed 2 lines)"
+        items = extract_scannable_items(section.group(1))
+        n = len(items)
+        overlong = [i for i in items if rendered_line_count(i) > 2]
+        if not 5 <= n <= 10:
+            adjective = "too thin" if n < 5 else "too verbose"
+            checks["CAP-REL-006-02-02_whats_new"] = (
+                f"FAIL (found {n} scannable items; need 5-10 — {adjective})"
+            )
+        elif overlong:
+            checks["CAP-REL-006-02-02_whats_new"] = (
+                f"FAIL ({n} scannable items but {len(overlong)} exceed 2 rendered lines)"
+            )
+        else:
+            checks["CAP-REL-006-02-02_whats_new"] = f"PASS ({n} scannable items, each <=2 lines)"
 
-    # CAP-REL-006-02-03: Compatibility section
-    has_compat = bool(re.search(r'##\s+Compatibility|##\s+No\s+breaking\s+changes|No breaking changes\.', body, re.IGNORECASE))
-    results["checks"]["CAP-REL-006-02-03_compatibility"] = "PASS" if has_compat else "FAIL (no Compatibility section or 'No breaking changes' statement)"
+    # -03: Compatibility section
+    has_compat = "compatibility" in h2_labels or bool(
+        re.search(r"No breaking changes", body, re.IGNORECASE)
+    )
+    checks["CAP-REL-006-02-03_compatibility"] = (
+        "PASS" if has_compat
+        else "FAIL (no Compatibility section or 'No breaking changes' statement)"
+    )
 
-    # CAP-REL-006-02-04: Sleeping-CAPs Disclosure (CONDITIONAL — required if SPEC-LANDED-IMPL-DEFERRED present)
-    mentions_sleeping = bool(re.search(r'SPEC-LANDED|sleeping[\s-]*CAP|grace[\s-]*extend', body, re.IGNORECASE))
-    has_disclosure = bool(re.search(r'##\s+Sleeping[\s-]*CAPs?', body, re.IGNORECASE))
-    if mentions_sleeping:
-        results["checks"]["CAP-REL-006-02-04_sleeping_disclosure"] = "PASS" if has_disclosure else "FAIL (mentions sleeping CAPs but lacks dedicated disclosure section)"
+    # -04: registered section vocabulary + required disclosure per applicable class
+    unregistered = [h for h in h2_labels if h not in REGISTERED_SECTIONS]
+    mentions_sleeping = bool(
+        re.search(r"SPEC-LANDED|sleeping[\s-]*CAP|grace[\s-]*extend", body, re.IGNORECASE)
+    )
+    has_sleeping_section = any(
+        DISCLOSURE_SECTIONS.get(h) == "deferred_capability" for h in h2_labels
+    )
+    if unregistered:
+        checks["CAP-REL-006-02-04_disclosure"] = (
+            f"FAIL (unregistered section name(s): {unregistered}; "
+            f"'(or equivalent)' withdrawn in v1.18.0)"
+        )
+    elif mentions_sleeping and not has_sleeping_section:
+        checks["CAP-REL-006-02-04_disclosure"] = (
+            "FAIL (mentions sleeping CAPs but lacks a Sleeping-CAPs Disclosure section)"
+        )
     else:
-        results["checks"]["CAP-REL-006-02-04_sleeping_disclosure"] = "PASS (not applicable)"
+        classes = sorted({
+            DISCLOSURE_SECTIONS[h] for h in h2_labels if h in DISCLOSURE_SECTIONS
+        })
+        detail = ", ".join(classes) if classes else "no disclosure class applicable"
+        checks["CAP-REL-006-02-04_disclosure"] = f"PASS ({detail})"
 
-    # CAP-REL-006-02-05: CHANGELOG link resolves
-    changelog_links = re.findall(r'https?://[^\s\)]+(?:CHANGELOG|AGET_DELTA|release-notes)[^\s\)]*\.(?:md|html)?', body)
-    if changelog_links:
-        # Check at least one resolves
-        resolves = any(url_resolves(url) for url in changelog_links[:3])  # cap at 3 to limit network calls
-        results["checks"]["CAP-REL-006-02-05_link_resolves"] = "PASS" if resolves else f"FAIL (links found but none resolve: {changelog_links[:3]})"
+    # -05: CHANGELOG link resolves
+    links = re.findall(
+        r"https?://[^\s\)]+(?:CHANGELOG|AGET_DELTA|release-notes)[^\s\)]*\.(?:md|html)?", body
+    )
+    if not links:
+        checks["CAP-REL-006-02-05_link_resolves"] = (
+            "FAIL (no CHANGELOG/AGET_DELTA/release-notes link found)"
+        )
+    elif any(link_resolver(u) for u in links[:3]):
+        checks["CAP-REL-006-02-05_link_resolves"] = "PASS"
     else:
-        results["checks"]["CAP-REL-006-02-05_link_resolves"] = "FAIL (no CHANGELOG/AGET_DELTA/release-notes link found)"
+        checks["CAP-REL-006-02-05_link_resolves"] = f"FAIL (links found but none resolve: {links[:3]})"
 
-    # CAP-REL-006-02-06: WITHDRAWN at authoring (replaced by 02-07 precedent-grounded)
+    # -06 is WITHDRAWN: intentionally not validated, and intentionally not emitted.
 
-    # CAP-REL-006-02-07: Body length 12-25 non-blank lines (precedent v3.15+v3.16 range)
-    nonblank = len([line for line in body.split('\n') if line.strip()])
-    byte_size = len(body.encode('utf-8'))
+    # -07: body length 12-25 non-blank lines
+    nonblank = len([ln for ln in body.split("\n") if ln.strip()])
+    byte_size = len(body.encode("utf-8"))
     if 12 <= nonblank <= 25:
-        results["checks"]["CAP-REL-006-02-07_length"] = f"PASS ({nonblank} nonblank lines, {byte_size} bytes within precedent 12-25/1500-2500)"
-    elif nonblank < 12:
-        results["checks"]["CAP-REL-006-02-07_length"] = f"FAIL ({nonblank} nonblank lines; need 12-25 — too thin)"
+        checks["CAP-REL-006-02-07_length"] = (
+            f"PASS ({nonblank} nonblank lines, {byte_size} bytes within precedent 12-25/1500-2500)"
+        )
     else:
-        results["checks"]["CAP-REL-006-02-07_length"] = f"FAIL ({nonblank} nonblank lines; need 12-25 — too verbose, exceeds precedent)"
+        adjective = "too thin" if nonblank < 12 else "too verbose, exceeds precedent"
+        checks["CAP-REL-006-02-07_length"] = (
+            f"FAIL ({nonblank} nonblank lines; need 12-25 — {adjective})"
+        )
 
-    # CAP-REL-006-02-08: Exactly 3 H2 sections
-    h2_sections = re.findall(r'^##\s+', body, re.MULTILINE)
-    h2_count = len(h2_sections)
-    if h2_count == 3:
-        results["checks"]["CAP-REL-006-02-08_sections"] = "PASS (3 H2 sections per precedent)"
+    # -08: core pair present; no fixed total-section count
+    missing_core = [label for label in ("what's new", "compatibility") if label not in h2_labels]
+    if missing_core:
+        checks["CAP-REL-006-02-08_sections"] = (
+            f"FAIL (missing required core section(s): {missing_core})"
+        )
     else:
-        results["checks"]["CAP-REL-006-02-08_sections"] = f"FAIL ({h2_count} H2 sections; need exactly 3)"
+        checks["CAP-REL-006-02-08_sections"] = (
+            f"PASS (core pair present; {len(h2_labels)} H2 sections, no fixed count)"
+        )
 
-    # CAP-REL-006-02-09: Title format (no duplicated v{X.Y.Z} prefix)
-    # Note: title not in body; this check requires gh release view --json name separately.
-    # When called from main() with repo+version context, fetch title and validate.
-    # Stub here returns PASS-deferred; main() will populate via gh CLI.
+    # -09: release title format
+    if title is None:
+        checks["CAP-REL-006-02-09_title"] = (
+            "UNAVAILABLE (no release title supplied; pass title= or use main(), "
+            "which fetches `gh release view --json name`)"
+        )
+    else:
+        checks["CAP-REL-006-02-09_title"] = _validate_title(title, version)
 
-    # Overall verdict
-    if any(check.startswith("FAIL") for check in results["checks"].values()):
+    if any(v.startswith("FAIL") for v in checks.values()):
         results["overall"] = "FAIL"
+    elif any(v.startswith("UNAVAILABLE") for v in checks.values()):
+        results["overall"] = "UNAVAILABLE"
 
     return results
 
 
+def _validate_title(title: str, version: str) -> str:
+    """CAP-REL-006-02-09: title is `v{X.Y.Z} - {theme}` or em-dash; version appears exactly once."""
+    tag = f"v{version}"
+    occurrences = len(re.findall(re.escape(tag), title))
+    if occurrences == 0:
+        return f"FAIL (title does not contain {tag}: {title!r})"
+    if occurrences > 1:
+        return f"FAIL (title contains {tag} {occurrences} times; must appear exactly once: {title!r})"
+    if not re.match(rf"^{re.escape(tag)}\s+[-–—]\s+\S", title.strip()):
+        return f"FAIL (title must be `{tag} - theme` or `{tag} — theme`: {title!r})"
+    return f"PASS ({title!r})"
+
+
 def main():
-    parser = argparse.ArgumentParser(description="Validate GitHub Release body per CAP-REL-006-02-NN")
+    parser = argparse.ArgumentParser(description="Validate a GitHub Release per CAP-REL-006-02-NN")
     parser.add_argument("--version", required=True, help="Version to validate (e.g., 3.17.0)")
     parser.add_argument("--repo", help="Single repo (e.g., aget-framework/aget); default = all 14")
     parser.add_argument("--all-repos", action="store_true", help="Validate all 14 repos")
@@ -163,13 +283,19 @@ def main():
 
     for repo in repos:
         try:
-            body = fetch_release_body(repo, args.version)
-            result = validate_body(repo, args.version, body)
+            body = fetch_release_field(repo, args.version, "body")
+            try:
+                title = fetch_release_field(repo, args.version, "name")
+            except RuntimeError:
+                title = None  # -09 will emit UNAVAILABLE rather than vanish
+            result = validate_body(repo, args.version, body, title=title)
             all_results.append(result)
-            if result["overall"] == "FAIL":
+            if result["overall"] != "PASS":
                 any_fail = True
         except Exception as e:
-            all_results.append({"repo": repo, "version": args.version, "error": str(e), "overall": "ERROR"})
+            all_results.append(
+                {"repo": repo, "version": args.version, "error": str(e), "overall": "ERROR"}
+            )
             any_fail = True
 
     if args.json:
@@ -181,9 +307,13 @@ def main():
                 print(f"  ERROR: {r['error']}")
             else:
                 for check_id, status in r["checks"].items():
-                    marker = "✅" if status.startswith("PASS") else "❌"
-                    print(f"  {marker} {check_id}: {status}")
-        print(f"\n{'='*50}\nSummary: {sum(1 for r in all_results if r['overall'] == 'PASS')}/{len(all_results)} repos PASS")
+                    marker = "PASS" if status.startswith("PASS") else (
+                        "WARN" if status.startswith("UNAVAILABLE") else "FAIL"
+                    )
+                    print(f"  [{marker}] {check_id}: {status}")
+                print(f"  ({len(r['checks'])}/{len(LIVE_SUBREQUIREMENTS)} live sub-requirements emitted)")
+        passing = sum(1 for r in all_results if r["overall"] == "PASS")
+        print(f"\n{'='*50}\nSummary: {passing}/{len(all_results)} repos PASS")
 
     sys.exit(1 if any_fail else 0)
 


### PR DESCRIPTION
Aligns `AGET_RELEASE_SPEC` v1.17.1 → v1.18.0 with the three authoring templates and the validator that checks them, then hardens the validator's test suite.

## What changed

| Surface | Change |
|---|---|
| `specs/AGET_RELEASE_SPEC.md` | v1.17.1 → **v1.18.0** — release-body contract aligned |
| `sops/SOP_release_process.md` | v1.33 → **v1.34** |
| `sops/templates/RELEASE_BODY_TEMPLATE_core.md` | authoring surface aligned to contract |
| `sops/templates/RELEASE_BODY_TEMPLATE_template.md` | authoring surface aligned to contract |
| `templates/TEMPLATE_RELEASE_BODY.md` | authoring surface aligned to contract |
| `verification/validate_release_body.py` | validator aligned to the contract it enforces |
| `tests/test_validate_release_body.py` | **new** — 40 tests |

## Why

`CAP-REL-006-02` encoded a release-body form the voice had abandoned, and the disclosure section carried nine names for four speech acts. The spec, the three authoring templates, and the validator had each drifted separately, so a release body could satisfy one surface and fail another.

## Verification

- `tests/test_validate_release_body.py` — **40 passed**
- Full canonical suite — **543 passed, 7 skipped, 0 failed** (no regression)
- Test hardening (`1a77692`) closed three gaps mutation testing found; **15/15 mutants killed**

Both commits were authored 2026-08-17 against base `8f85772` and rebased onto current `main` for this PR; the rebase was clean and the suite was re-run after it, not before.

Closes gmelli/aget-aget#2004 on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)