### PR TITLE
docs: mark SOP_cross_aget_communication as fleet-internal at both citation sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,7 +269,7 @@ Defects found by *executing* the gates rather than reading them — each had shi
 - **`/aget-create-initiative`** deployed to canonical core (STRICT, D71). **⚠️ Errata (2026-06-07, gh#1461):** this does **not** close the verb-pair gap as originally stated — the producer half (`/aget-propose-initiative` skill) and `SOP_initiative.md` are **not** shipped in canonical at this tag, so the STRICT route is **non-functional** (it refuses without an APPROVED `PROPOSAL_init_*.md` and `cat`s an absent SOP). The route is **gated (not enforced)** until the producer half ships. See gh#1461.
 
 ### Changed
-- **IAC SOP** (`SOP_cross_aget_communication.md`) per-pattern maturity reconciliation (P1 Relay + P1.5 Read-at-Source → Implemented; cross-machine patterns honestly Pending).
+- **IAC SOP** (`SOP_cross_aget_communication.md` — *fleet-internal, not shipped in this package*) per-pattern maturity reconciliation (P1 Relay + P1.5 Read-at-Source → Implemented; cross-machine patterns honestly Pending).
 - **Release observability** (C-21-16): release-metrics ledger now live-captures real build-gate data; `deployment_monitor.py` outcome-record crash fixed (gh#1589).
 
 ---

--- a/sops/SOP_sop_creation.md
+++ b/sops/SOP_sop_creation.md
@@ -378,6 +378,9 @@ Phase 2: Graduation (Skip - consolidation path)
 
 Phase 3: Creation
 - Created sops/SOP_cross_aget_communication.md
+  *(fleet-internal — maintained in the framework manager's private repository and **not** shipped in
+  this public package. Annotated 2026-08-22: the bare reference read as a pointer to a file in this
+  repo, which does not exist here.)*
 - Included all required sections
 - Referenced all 5 L-docs
 


### PR DESCRIPTION
Both sites named a SOP that does not exist in this package, so a reader followed the pointer and reached nothing:

- `sops/SOP_sop_creation.md:380` — a bare `- Created sops/SOP_cross_aget_communication.md` line
- `CHANGELOG.md:272` — a `### Changed` entry under released `[3.21.0]`, reporting two of its patterns as Implemented

The SOP is real; it is maintained in a private repository and is not shipped here. This change annotates both references rather than rewriting the history or vendoring a fleet-internal document.

## Scope

These are **2 of a measured 29** dangling SOP citations in this repo: 48 distinct `SOP_*.md` names are cited, 19 are tracked in `sops/`. The split matters more than the total — only 4 are changelog-only history; **25 are live pointers** from documents a reader is meant to follow (specs, SOPs, templates, skills), and 17 name SOPs that exist only in a private repository.

The most consequential one not fixed here is `templates/TEMPLATE_PROJECT_PLAN.md:6`, which carries such a pointer into 13 template repositories. The remainder is a scoped remediation, deliberately not bundled into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)