### PR TITLE
v3.32.0: repair two release-evidence controls

### DIFF
--- a/.aget/version.json
+++ b/.aget/version.json
@@ -1,7 +1,7 @@
 {
-  "aget_version": "3.31.1",
+  "aget_version": "3.32.0",
   "created": "2025-09-21",
-  "updated": "2026-08-18",
+  "updated": "2026-08-23",
   "component": "core",
   "description": "AGET Framework Core - Specifications, templates, and validation",
   "repository": "aget-framework/aget",
@@ -50,7 +50,8 @@
     "v3.28.0 -> v3.29.0: 2026-08-01",
     "v3.29.0 -> v3.30.0: 2026-08-08",
     "v3.31.0: 2026-08-15 (promotion leg \u2014 five verification instruments reach canonical)",
-    "v3.31.0 -> v3.31.1: 2026-08-18 (receiver-safe close-gate correction package)"
+    "v3.31.0 -> v3.31.1: 2026-08-18 (receiver-safe close-gate correction package)",
+    "v3.31.1 -> v3.32.0: 2026-08-23 (two-item corrective release: cadence source disclosure, three-state deprecation evidence)"
   ],
   "contents": {
     "specs/": "Canonical specifications (AGET_VERSIONING_CONVENTIONS, etc.)",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [3.32.0] - 2026-08-23 - "Truthful Release Evidence"
+
+Two repairs to controls that report on releases. Both failed at their shipped public subjects in v3.31.1.
+
+### Fixed
+
+- **`release_cadence_gap.py` no longer answers about a subject nobody asked for.** An explicit source that
+  did not resolve was silently replaced with a different one, and the tool reported success (exit 0). An
+  explicit input that cannot be read is now `UNAVAILABLE` (exit 2) — never substituted, and never conflated
+  with `BREACHED` (exit 1, which means the subject *was* read). Discovery applies only when no explicit
+  input was given, and the winning strategy is disclosed in the output.
+- **Terminal-`Z` tagger dates now parse on Python 3.10.** `datetime.fromisoformat` rejects a trailing `Z`
+  and colon-less UTC offsets before 3.11; the script crashed with exit 1 and empty stdout, which callers
+  could not distinguish from a legitimate `BREACHED` verdict.
+- **`check_deprecation_removals.py` reports three states over a real population.** The checker takes an
+  injectable subject and names it in its output.
+
+### Added
+
+- **`governance/DEPRECATIONS.md`** — the public deprecation registry. Before this, the default invocation
+  of the deprecation checker exited 2 against a public checkout because there was nothing to read.
+- **`tests/test_release_cadence_gap_source_contract.py`** — both-polarity source-resolution contract,
+  including a deterministic UTC tagger-date regression, and a guard that refuses to read exit 1 as a
+  verdict unless stdout carries valid JSON.
+
+---
+
 ## [3.31.1] - 2026-08-18 - "Receiver-Safe Close Gates"
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -16,8 +16,8 @@ authors:
 repository-code: "https://github.com/aget-framework/aget"
 url: "https://github.com/aget-framework"
 license: Apache-2.0
-version: 3.31.1
-date-released: '2026-08-18'
+version: 3.32.0
+date-released: '2026-08-23'
 
 abstract: |
   AGET is a platform-agnostic governance framework for CLI-based human-AI

--- a/DEPLOYMENT_SPEC_v3.32.0.yaml
+++ b/DEPLOYMENT_SPEC_v3.32.0.yaml
@@ -1,0 +1,51 @@
+schema_version: "1.0"
+version: "3.32.0"
+released: "2026-08-23"
+name: "Truthful Release Evidence"
+type: corrective
+
+breaking_changes: NONE
+
+scope:
+  product_items: 2
+  description: >
+    Two repairs to release-evidence controls. No new capability, no API change,
+    no migration required.
+
+exit_code_semantics:
+  release_cadence_gap:
+    0: OK
+    1: BREACHED — the subject was read and the cadence gap exceeds the rule
+    2: UNAVAILABLE — the named subject could not be read; never substituted
+    note: >
+      Exit 1 alone is not a verdict. A caller must require non-empty valid JSON
+      on stdout before reading exit 1 as BREACHED, because a crash also exits 1.
+  check_deprecation_removals:
+    0: PASS
+    1: FAIL
+    2: UNAVAILABLE
+
+deployment_requirements:
+  - Python >= 3.10 (terminal-Z tagger dates parse on 3.10 as of this release)
+  - No configuration change required
+  - No data migration required
+
+smoke_test:
+  - "python3 scripts/release_cadence_gap.py --json   # exits 0/1/2, always emits JSON"
+  - "python3 scripts/check_deprecation_removals.py --json   # resolves governance/DEPRECATIONS.md"
+
+rollback:
+  method: revert-on-main
+  note: >
+    History rewrite is barred by the non_fast_forward rule on main. Rollback is a
+    revert commit, not a force-push.
+
+not_delivered:
+  - id: C-32-03
+    reason: >
+      Verified private candidate. No canonical counterpart; awaits a governed
+      public name, path, and consumer. NOT publicly delivered.
+  - id: C-32-04
+    reason: >
+      The public templates lack the cited surface. Full template modernization is
+      outside this corrective release. Private fix preserved, NOT shipped.

--- a/codemeta.json
+++ b/codemeta.json
@@ -7,9 +7,9 @@
   "license": "https://spdx.org/licenses/Apache-2.0",
   "codeRepository": "https://github.com/aget-framework/aget",
   "issueTracker": "https://github.com/aget-framework/aget/issues",
-  "version": "3.31.1",
+  "version": "3.32.0",
   "dateCreated": "2025-11-21",
-  "dateModified": "2026-08-18",
+  "dateModified": "2026-08-23",
   "programmingLanguage": [
     "Python",
     "YAML",

--- a/governance/DEPRECATIONS.md
+++ b/governance/DEPRECATIONS.md
@@ -1,0 +1,91 @@
+# AGET Framework — Deprecation Registry
+
+**Status**: PREPARED CANDIDATE — not published. Target `aget-framework/aget` → `governance/DEPRECATIONS.md`.
+
+**Scope**: deprecations a **public consumer of the AGET framework** can act on. A row is here only if the
+deprecation changes something you do — migrate a call, re-cite a path, stop relying on a flag. Deprecations
+that bind only the maintainer's own installation are deliberately **excluded**; see *What is not here*.
+
+Every row carries the five `R-DEP-010` fields: **what** is deprecated, **why**, its **replacement**, a
+**removal timeline**, and how to **detect** it. A removal timeline nobody can detect is decorative metadata,
+so the detection instruction sits in the Status column and is not optional.
+
+**Grace policy** (`R-DEP-011`): non-breaking deprecations carry a two-minor grace window — marked in vN,
+carried in vN+1, removable in vN+2. Breaking changes wait for the next major.
+
+---
+
+## Active — act on these
+
+| Item | What is deprecated, and why | Replacement | Earliest removal | Status and detection |
+|---|---|---|---|---|
+| **DEP-BASENAME-VPP-001** | The script **name** `scripts/validate_project_plan.py` — the name only, not the behaviour. The code is unchanged and now lives at `scripts/validate_execution_authorization.py`. **Why**: the name asserted a predicate the script never had. It checks whether *any* governance artifact exists — its subject is the *action* — and it never validated a plan. A different, larger file, `verification/validate_project_plan.py`, *does* validate plans; its subject is the *document*. One basename, two referents, opposite questions. The collision was cashed as six false "safe to proceed" reports on 2026-07-26 before it was classified. | **Authorization gate** → `scripts/validate_execution_authorization.py`. **Plan conformance** → `verification/validate_project_plan.py <path> --strict`. A delegating shim remains at the old name for the grace window: same stdout, same exit codes, `DeprecationWarning` on stderr. | **v3.34.0** — marked v3.32 → carried v3.33 → shim removable v3.34 (`R-DEP-011`, non-breaking two-minor grace) | **Active — grace window open.** **Detection**: `rg -n 'validate_project_plan' .` in your own repository. A hit that names the basename **without a directory** is ambiguous between the two files in the Replacement column regardless of which was meant, and should be re-cited with its path. A hit that invokes `scripts/validate_project_plan.py` is a live call site on the deprecated name and will stop working at v3.34.0. |
+
+## Closed — history, no action required
+
+Kept because the artifacts they describe are still visible in public distributions, so a reader can still
+encounter the old name and needs to know its disposition.
+
+| Item | What was deprecated, and why | Replacement | Earliest removal | Status and detection |
+|---|---|---|---|---|
+| **DEP-FIX-FLAG-001** | The `/aget-check-health --fix` flag. **Why**: documented across skill files and a skill specification, never implemented — a remediation promise with nothing behind it. | `/aget-enhance-health` (SKILL-049), the canonical `check → enhance` pipeline per `DESIGN_DIRECTION` §Principle 9. | v3.15.0 — immediate; the `R-DEP-011` grace window is for artifacts that worked, and this one never did | **Removed in v3.15.0.** **Detection**: `rg -n '\-\-fix' .aget/specs/skills/ .claude/skills/` — the flag no longer exists in any code path. Statements describing it may still be readable in older skill specifications; they document a flag that was never functional. |
+| **DEP-REQ-HOM-F-006** | Requirement REQ-HOM-F-006, *Content Preservation During Rewrites*. **Why**: it defended an inline-preservation pattern that the current homepage architecture no longer uses, so the requirement protected a non-canonical layout. | No successor requirement. Preservation is now structural rather than stated: a consolidated release-notes archive, per-version GitHub Release bodies, and `CHANGELOG.md`, all linked from the "Earlier Releases" section. | v3.20.0 — `R-DEP-011` non-breaking two-minor grace from v3.18.0 | **Retired in v3.18.0.** **Detection**: `rg -n 'REQ-HOM-F-006' requirements/` — the requirement block is retained in `requirements/REQ-HOM_homepage_quality.md` with `status: retired` and a five-field retirement record. Cite it only as history. |
+
+---
+
+## Keeping this registry true — the maintenance loop
+
+A public registry derived from a private one, with nothing binding them, decays silently. This is the
+binding. It is deliberately small enough to actually run.
+
+| | |
+|---|---|
+| **Owner** | The framework release agent — the same role that executes the release process and owns `sops/SOP_release_process.md`. Ownership is a role, not a person, so it survives handoffs. |
+| **Trigger** | Any change to the source registry, **and** every release. Whichever comes first. A deprecation is *created* by a release and *discharged* by a release, so the release is the only event guaranteed to catch both. |
+| **Review** | Run the checker against this file: `python3 scripts/check_deprecation_removals.py --registry governance/DEPRECATIONS.md --json`. It returns `PASS` (every row inside its grace window), `FAIL` (a removal version has passed with the row still open), or `UNAVAILABLE` (it could not read the registry — never a silent pass). Then re-apply the consumer-actionability test to any row added to the source since the last pass: does it change what a consumer does? |
+| **Consequence** | The check runs in the release gate battery. `FAIL` means the release ships an unactuated rule: either remove the artifact and mark the row, or re-baseline the removal version **with a stated reason**. A row may not simply be carried again in silence — that is the failure this file exists to make visible. `UNAVAILABLE` blocks the same way `FAIL` does; an unread registry is not a clean one. |
+| **Cadence** | Per release. Between releases the trigger is event-driven, not scheduled — a calendar reminder over an unchanged file produces noise and trains the reader to skip it. |
+| **Falsifier** | If this file's row set ever diverges from the source registry's public-scoped rows and neither the checker nor the release gate says so, the loop is not working, whatever the process document claims. |
+
+## What is not here, and why
+
+**Rows that bind only the maintainer's own installation are excluded.** The source registry governs an
+internal governance tree and carries entries a consumer cannot possess, cannot detect, and cannot act on.
+Publishing them would present noise as policy: the reader cannot tell them apart from rows that do bind.
+Two of the source registry's five rows were excluded on this basis:
+
+- a retired clause in an internal ontology definition — the file is not distributed;
+- a deprecated shell script that **was never in any public distribution**. Verified at source rather than
+  assumed: the path is absent from the release tag that announced the deprecation, absent from the current
+  release tag, and absent from every commit on every public branch, while a control file checked with the
+  identical command at the identical commits was found. Its replacement already shipped, and always had.
+  There is nothing for a consumer to migrate from.
+
+**This is a split, not a copy.** It is derived from a larger internal registry and re-scoped, so it does not
+track that file automatically. That obligation is the maintenance loop above, which is why the loop names a
+consequence rather than an intention.
+
+**Sanitization applied**: references to internal installation paths were removed or replaced with the public
+path of the same artifact. Where an internal measurement supported a claim, the claim was kept and the
+measurement's internal detail dropped.
+
+## Known limitations of this draft
+
+1. **Detection commands have not been exercised against a plain consumer checkout.** They were authored
+   against the maintainer's corpus, then rewritten to remove tree-specific path exclusions. They should run
+   anywhere `rg` is available, but "should" is not "was measured".
+2. **The Active row's possession leg is weak, and this is deliberate.** The deprecated script is not itself
+   distributed publicly; what *is* public is the other file the name collides with. The row is here because
+   the **ambiguity** is a consumer's problem, not because the consumer holds the deprecated file. If a
+   reviewer rejects that reasoning, the correct consequence is that this registry has zero Active rows —
+   not that a different row should be added to fill the section.
+3. **One row's specification text outlived its removal.** `DEP-FIX-FLAG-001` was removed in v3.15.0, but
+   statements describing the flag are still readable in a public skill specification. The row is what
+   resolves the contradiction for a reader who finds them; the specification itself is not repaired here.
+
+## Why this artifact exists
+
+An announced deprecation its audience cannot see is an overclaim. The Active row above is scheduled for
+removal on a published timeline, and until this file ships there is **no public surface on which a consumer
+can discover it**. The framework's own removal checker returns `UNAVAILABLE` against a public checkout for
+exactly the same reason: the registry it reads does not ship.

--- a/handoffs/DELIVERED_FILES_v3.32.0.yaml
+++ b/handoffs/DELIVERED_FILES_v3.32.0.yaml
@@ -20,6 +20,10 @@ core:
   release_metadata:
     - path: .aget/version.json
       change: modified
+    - path: codemeta.json
+      change: modified
+    - path: CITATION.cff
+      change: modified
     - path: CHANGELOG.md
       change: modified
     - path: DEPLOYMENT_SPEC_v3.32.0.yaml

--- a/handoffs/DELIVERED_FILES_v3.32.0.yaml
+++ b/handoffs/DELIVERED_FILES_v3.32.0.yaml
@@ -1,0 +1,54 @@
+schema_version: "1.0"
+version: "3.32.0"
+released: "2026-08-23"
+
+core:
+  repo: aget-framework/aget
+  payload:
+    - path: scripts/release_cadence_gap.py
+      change: modified
+      item: C-32-01
+    - path: tests/test_release_cadence_gap_source_contract.py
+      change: added
+      item: C-32-01
+    - path: scripts/check_deprecation_removals.py
+      change: modified
+      item: C-32-02
+    - path: governance/DEPRECATIONS.md
+      change: added
+      item: C-32-02
+  release_metadata:
+    - path: .aget/version.json
+      change: modified
+    - path: CHANGELOG.md
+      change: modified
+    - path: DEPLOYMENT_SPEC_v3.32.0.yaml
+      change: added
+    - path: release-notes/v3.32.0.md
+      change: added
+    - path: handoffs/RELEASE_HANDOFF_v3.32.0.md
+      change: added
+    - path: handoffs/REMOTE_MIGRATION_MESSAGE_v3.32.0.md
+      change: added
+    - path: handoffs/DELIVERED_FILES_v3.32.0.yaml
+      change: added
+
+templates:
+  registered_count: 13
+  delivered_count: 0
+  rationale: >
+    No template payload in this release. Both repairs are core-only scripts with
+    no template counterpart. The standard release topology is core plus 13
+    registered templates (14 repos); this cycle touches core alone, and that is
+    a scope fact rather than an omission.
+  registry_note: >
+    13 is the registered template count, derived from the template repository
+    register. It is not a directory glob.
+
+not_delivered:
+  - id: C-32-03
+    state: verified private candidate
+    reason: no canonical counterpart; awaits governed public name, path, consumer
+  - id: C-32-04
+    state: verified private fix
+    reason: public templates lack the cited surface; modernization out of scope

--- a/handoffs/RELEASE_HANDOFF_v3.32.0.md
+++ b/handoffs/RELEASE_HANDOFF_v3.32.0.md
@@ -1,0 +1,52 @@
+# Release Handoff — v3.32.0 "Truthful Release Evidence"
+
+**Version**: 3.32.0 · **Released**: 2026-08-23 · **Type**: corrective · **Breaking changes**: none
+**Producer**: framework manager · **Consumer**: supervisor-class seats (fleet upgrade coordination)
+
+## Summary
+
+Two release-evidence controls were reporting wrongly at their shipped public subjects. Both are repaired.
+
+1. **`release_cadence_gap.py`** silently substituted a different source when the named one did not resolve,
+   and exited 0. Now `UNAVAILABLE` (exit 2), never substituted, never conflated with `BREACHED`. The
+   winning resolution strategy is disclosed in the output. A Python 3.10 crash on terminal-`Z` tagger dates
+   is fixed in the same area.
+2. **`check_deprecation_removals.py`** had no public registry to read, so the default invocation exited 2.
+   `governance/DEPRECATIONS.md` now ships, and the checker names the subject it measured.
+
+## Upgrade Guide
+
+Pull the release. No configuration change, no migration, no API change. Consumers of the cadence tool
+should read `handoffs/REMOTE_MIGRATION_MESSAGE_v3.32.0.md` for the exit-code contract — in particular that
+**exit 1 is not a verdict without valid JSON on stdout**.
+
+## Scope, stated exactly
+
+**Two product items.** Two further candidates were verified and are **carried forward, NOT delivered**:
+
+| Item | State |
+|---|---|
+| `C-32-03` | Verified private candidate. No canonical counterpart; awaits a governed public name, path, and consumer. **Do not describe as delivered.** |
+| `C-32-04` | Verified private fix. Public templates lack the cited surface; modernization is out of scope. **Do not describe as delivered.** |
+
+## Release topology
+
+Core plus **13 registered templates** (14 repos). **This cycle touches core only** — both repairs are
+core-side scripts with no template counterpart. Zero template payload is a scope fact, not an omission.
+
+## Known state at handoff — read before deploying
+
+| Item | State |
+|---|---|
+| Value floor | **FAILED and OVERRIDDEN, not passed.** Locked Tier-1 carries zero V1=L3 rows; cleared by recorded exception. Fourth override this cycle |
+| Independent review | **Budget unspent** at time of writing; one review is owed at the stable PR head |
+| Python 3.10 verification | Repair is by construction; **execution on 3.10 was UNAVAILABLE at the producer seat** |
+
+## Pilot Tracking
+
+| Seat | Version confirmed | Behavioural proof | Date | Notes |
+|---|---|---|---|---|
+| *(pending)* | | | | Awaiting deployment |
+
+**Deployment verification is a release-completion obligation, not a pre-publication blocker.** Producer
+owns this artifact and the release execution; **fleet upgrade coordination is the supervisor's.**

--- a/handoffs/REMOTE_MIGRATION_MESSAGE_v3.32.0.md
+++ b/handoffs/REMOTE_MIGRATION_MESSAGE_v3.32.0.md
@@ -1,0 +1,41 @@
+# v3.32.0 — Remote Migration Message
+
+**Version**: 3.32.0 · **Released**: 2026-08-23 · **Type**: corrective
+
+## Breaking Changes
+
+**None.**
+
+## Upgrade Guide
+
+Pull the release. No configuration change, no data migration, no API change.
+
+If you consume `release_cadence_gap.py` programmatically, note the exit-code contract, which is now
+enforced rather than implied:
+
+| Exit | Meaning |
+|---|---|
+| 0 | OK |
+| 1 | `BREACHED` — the subject **was read** and exceeds the cadence rule |
+| 2 | `UNAVAILABLE` — the named subject could not be read. **Never substituted** |
+
+**Do not read exit 1 as a verdict on its own.** A crash also exits 1. Require non-empty valid JSON on
+stdout before interpreting it as `BREACHED`.
+
+## Deployment Requirements
+
+Python >= 3.10. Terminal-`Z` git tagger dates parse correctly on 3.10 as of this release.
+
+## Smoke Test
+
+```bash
+python3 scripts/release_cadence_gap.py --json        # exits 0/1/2, always emits JSON
+python3 scripts/check_deprecation_removals.py --json # resolves governance/DEPRECATIONS.md
+```
+
+Both should emit JSON naming the subject they measured.
+
+## Rollback
+
+Revert-on-`main`. History rewrite is barred by the `non_fast_forward` rule, so rollback is a revert
+commit rather than a force-push.

--- a/release-notes/v3.32.0.md
+++ b/release-notes/v3.32.0.md
@@ -1,0 +1,33 @@
+# v3.32.0 — Truthful Release Evidence
+
+**Released**: 2026-08-23 · **Type**: corrective · **Breaking changes**: none
+
+Two tools that report on releases were themselves reporting wrongly. This release repairs both.
+
+## The cadence tool answered about the wrong subject
+
+If you named a source that did not resolve, the tool silently substituted a different one, measured that,
+and exited 0. You got a confident answer about something you did not ask about — which is worse than an
+error, because an error stops you.
+
+Now: an explicit input that cannot be read is `UNAVAILABLE` (exit 2). It is never replaced, and never
+conflated with `BREACHED` (exit 1, which means the subject genuinely *was* read). Discovery applies only
+when you gave no explicit input, and the output names which rule won.
+
+A related crash is fixed in the same area: on Python 3.10, `datetime.fromisoformat` rejects a trailing `Z`
+in git tagger dates. The tool died with exit 1 and empty output — indistinguishable, from the outside, from
+a real `BREACHED` result. Terminal `Z` and colon-less offsets now normalize before parsing, and the test
+contract refuses to read exit 1 as a verdict unless stdout carries valid JSON.
+
+## The deprecation checker had nothing to check
+
+Against a public checkout, the default invocation exited 2 — there was no registry. `governance/DEPRECATIONS.md`
+now ships as the public registry, and the checker takes an injectable subject and names it in its output,
+so a default run returns a real verdict over a real population.
+
+## Scope
+
+Two items. Four payload files plus release metadata. Two further candidates were verified and are
+**carried forward, not delivered** — one has no canonical home yet, and the other's public target is
+generations away from the private one, which would have made it a much larger change than a corrective
+release should carry. They are not described as shipped anywhere in this release.

--- a/scripts/check_deprecation_removals.py
+++ b/scripts/check_deprecation_removals.py
@@ -27,28 +27,141 @@ THREE-STATE per CONVENTION_check_three_state_contract: PASS / FAIL / UNAVAILABLE
 whose removal version cannot be parsed is reported UNAVAILABLE, never silently skipped —
 an unparseable row must not read as a clean one (the zero-denominator family, gh#2045).
 
-Exit codes:
-    0 — PASS (no row is past its removal version while un-removed), or advisory mode
-    1 — FAIL (>=1 row overdue)
-    2 — UNAVAILABLE (registry or version.json unreadable)
+THE EXIT CODE CARRIES THAT STATE — it did not until 2026-08-21 (v3.32 Gate 1). `classify()`
+had returned UNAVAILABLE correctly and `main()` had counted it correctly, and then ended
+`return 1 if fails else 0`, which reads only the FAIL bucket. So a registry that was READ
+but not MEASURED exited 0: an active row whose removal cell carries no semver, an
+unreadable `.aget/version.json` making every active row unclassifiable, or a readable file
+that parsed zero rows. The missing-registry UNAVAILABLE was never masked; the row-level one
+always was. Same defect shape as the rows it detects — a state reported in the body and
+dropped from the verdict.
 
+PRECEDENCE: UNAVAILABLE dominates FAIL. A population only partly measured cannot certify a
+whole-registry verdict, so the exit code names the weaker claim; the FAIL rows are still
+printed, still counted, and the code is still non-zero, so nothing that blocked before
+stops blocking. `--advisory` downgrades FAIL to a report and NEVER downgrades UNAVAILABLE —
+"I did not read the subject" is not a finding that an advisory slot may absorb.
+
+INJECTABLE SUBJECT (v3.32 AC-2, DR-3 — 2026-08-21). Until this repair, ROOT/REGISTRY were
+module constants derived from `__file__` and `--help` offered only `--json`/`--advisory`.
+The instrument could not be pointed at any registry but the one beside it, and its output
+never named the registry it read, so a reader could not tell which subject a verdict was
+about. Measured on shipped blob 50e29046b8b779b8d17a195d339549e0ddf3014a (identical at
+v3.31.0, v3.31.1 and the private working copy).
+
+Precedence — first hit wins, and the winner is ALWAYS disclosed:
+    1. --registry PATH                explicit, this exact file
+    2. --root DIR                     explicit, DIR/<default registry relpath>
+    3. AGET_DEPRECATION_REGISTRY      explicit, environment
+    4. this file's own repo root      discovery — the prior sole behaviour
+
+Both flags may be given together: --registry names the registry, --root names the tree
+whose `.aget/version.json` it is compared against. Neither silently overrides the other.
+
+An EXPLICIT input that does not resolve is UNAVAILABLE (exit 2). It is NEVER replaced by a
+fallback — that substitution is the sibling defect (AC-3/DR-1), where an instrument silently
+measured a different subject and exited 0.
+
+COHERENT SUBJECT. The registry and the version it is compared against must come from ONE
+tree. When only --registry is given, the root is derived FROM that registry (its
+`governance/` parent, else its own directory) — never from discovery. An earlier draft of
+this repair left VERSION_JSON resolving from the discovered root, so the registry came from
+one seat and the comparison version from another, silently, producing a clean PASS.
+
+EXIT 2 IS A SHARED NAMESPACE (L1432). `argparse` also exits 2 on a usage error, so exit
+status alone cannot distinguish UNAVAILABLE from "unrecognized arguments". Every genuine
+UNAVAILABLE therefore prints a second discriminator on stderr: a line beginning
+`UNAVAILABLE:` that names the subject and the strategy that chose it.
+
+Exit codes:
+    0 — PASS (every row was classified and none is past its removal version while
+        un-removed), or advisory mode over a FAIL
+    1 — FAIL (>=1 row overdue, and every row was classifiable)
+    2 — UNAVAILABLE, in any of four shapes, never masked by --advisory:
+          a. the declared registry could not be read;
+          b. the registry was read but parsed ZERO rows;
+          c. >=1 row could not be classified (short row, or no semver in its removal cell);
+          d. the current version could not be read, leaving active rows unclassifiable.
 
 Usage:
     python3 scripts/check_deprecation_removals.py [--json] [--advisory]
-
-Exit codes:
-    0  every registered deprecation is inside its grace window, or --advisory
-    1  at least one removal is overdue
-    2  registry unreadable or absent (UNAVAILABLE, never a silent pass)
+                                                  [--registry PATH] [--root DIR]
 """
 import argparse
 import json
+import os
 import pathlib
 import re
 import sys
 
+# Default discovery, in order. First existing candidate wins and the winner is disclosed.
+# Two names because one script serves two populations: this seat's governance registry
+# (`POLICY_deprecation.md`) and the consumer-facing public registry (`DEPRECATIONS.md`).
+# Discovery order is documented, disclosed in output, and applies ONLY when no explicit
+# input was given — it is a default, never a substitution for a rejected explicit subject.
+DEFAULT_REGISTRY_RELPATHS = (
+    "governance/POLICY_deprecation.md",
+    "governance/DEPRECATIONS.md",
+)
+
+
+def _discover(root):
+    """(registry_path, strategy) for a root with no explicit registry named."""
+    for rel in DEFAULT_REGISTRY_RELPATHS:
+        if (root / rel).is_file():
+            return root / rel, rel
+    # Nothing found: return the FIRST candidate so the UNAVAILABLE message names a real
+    # path rather than nothing, and disclose that discovery came up empty.
+    return root / DEFAULT_REGISTRY_RELPATHS[0], "none-of[" + ",".join(DEFAULT_REGISTRY_RELPATHS) + "]"
+
+
+def _root_for_registry(reg):
+    """The tree a registry belongs to, derived from the registry itself.
+
+    `<root>/governance/<name>.md` -> `<root>`; anything else -> the registry's own
+    directory. Never the discovered own-repo root: borrowing this file's repo version to
+    judge somebody else's registry is the split-subject defect, not a convenience.
+    """
+    return reg.parent.parent if reg.parent.name == "governance" else reg.parent
+
+
+def resolve_subject(registry=None, root=None, env=None, home=None):
+    """Resolve the subject this run measures.
+
+    Returns (registry_path, root_path, strategy, explicit) — `explicit` is True when an
+    operator named the subject, which is what makes a resolution failure UNAVAILABLE
+    rather than a fallback.
+    """
+    home = pathlib.Path(home) if home else pathlib.Path(__file__).resolve().parents[1]
+
+    if registry or root:
+        parts = []
+        if registry:
+            reg = pathlib.Path(registry)
+            parts.append(f"--registry={registry}")
+        if root:
+            rt = pathlib.Path(root)
+            parts.append(f"--root={root}")
+            if not registry:
+                reg, disc = _discover(rt)
+                parts.append(f"discovered={disc}")
+        else:
+            rt = _root_for_registry(reg)
+        return reg, rt, "explicit:" + " ".join(parts), True
+
+    if env:
+        reg = pathlib.Path(env)
+        return reg, _root_for_registry(reg), f"explicit:AGET_DEPRECATION_REGISTRY={env}", True
+
+    reg, disc = _discover(home)
+    return reg, home, f"discovered:own-repo-root+{disc}", False
+
+
+# Module-level defaults are DISCOVERY ONLY — no argv is parsed at import time. Importers
+# (the unit half of tests/test_deprecation_removal_check.py) get the historical behaviour;
+# main() rebinds these from the parsed arguments.
 ROOT = pathlib.Path(__file__).resolve().parents[1]
-REGISTRY = ROOT / "governance" / "POLICY_deprecation.md"
+REGISTRY, _, SUBJECT_STRATEGY, _ = resolve_subject()
 VERSION_JSON = ROOT / ".aget" / "version.json"
 
 # A registry row, split on "|", yields fixed positions:
@@ -70,20 +183,30 @@ def parse_semver(text):
     return tuple(int(g) for g in m.groups()) if m else None
 
 
-def current_version():
+def current_version(version_json=None):
+    vj = VERSION_JSON if version_json is None else pathlib.Path(version_json)
     try:
-        return parse_semver(json.loads(VERSION_JSON.read_text())["aget_version"])
+        return parse_semver(json.loads(vj.read_text())["aget_version"])
     except Exception:
         return None
 
 
-def rows():
+def rows(registry=None):
     """Registry rows, de-duplicated by id — the id appears in both the registry table
-    and the narrative section below it, and counting both would double the denominator."""
-    if not REGISTRY.exists():
+    and the narrative section below it, and counting both would double the denominator.
+
+    None means UNAVAILABLE: absent, a directory, or unreadable. An OSError here used to
+    escape as a traceback and exit 1, collapsing UNAVAILABLE into FAIL.
+    """
+    reg = REGISTRY if registry is None else pathlib.Path(registry)
+    if not reg.is_file():
+        return None
+    try:
+        text = reg.read_text(errors="ignore")
+    except OSError:
         return None
     seen, out = set(), []
-    for line in REGISTRY.read_text(errors="ignore").splitlines():
+    for line in text.splitlines():
         m = ROW.match(line)
         if not m:
             continue
@@ -134,21 +257,42 @@ def main():
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--advisory", action="store_true",
-                    help="report but always exit 0 (battery advisory slot)")
+                    help="downgrade FAIL to exit 0 (battery advisory slot); UNAVAILABLE is "
+                         "never downgraded")
+    ap.add_argument("--registry", metavar="PATH",
+                    help="explicit path to the deprecation registry (explicit: never falls back)")
+    ap.add_argument("--root", metavar="DIR",
+                    help="explicit tree root; registry discovered under DIR, version read "
+                         "from DIR/.aget/version.json")
     args = ap.parse_args()
 
-    reg = rows()
+    registry, root, strategy, explicit = resolve_subject(
+        args.registry, args.root, os.environ.get("AGET_DEPRECATION_REGISTRY"))
+    version_json = root / ".aget" / "version.json"
+
+    reg = rows(registry)
     if reg is None:
-        print(f"UNAVAILABLE: registry not found at {REGISTRY.relative_to(ROOT)}", file=sys.stderr)
+        # Exit 2 is shared with argparse's usage error (L1432), so the `UNAVAILABLE:`
+        # token on stderr is the discriminator a caller can actually test.
+        print(f"UNAVAILABLE: registry not readable at {registry}", file=sys.stderr)
+        print(f"UNAVAILABLE: subject chosen by {strategy}", file=sys.stderr)
+        if explicit:
+            print("UNAVAILABLE: the explicit input was rejected and NOT replaced by a "
+                  "fallback; no other subject was measured.", file=sys.stderr)
         return 2
 
-    cur = current_version()
+    cur = current_version(version_json)
     results = [dict(id=r["id"], **dict(zip(("state", "detail"), classify(r, cur)))) for r in reg]
     fails = [r for r in results if r["state"] == "FAIL"]
     unavail = [r for r in results if r["state"] == "UNAVAILABLE"]
 
     if args.json:
         print(json.dumps({
+            # Source disclosure is not decoration: a verdict whose subject is unnamed
+            # cannot be checked by its reader (v3.32 path-resolution contract, rule 2).
+            "registry": str(registry),
+            "registry_source": strategy,
+            "version_source": str(version_json),
             "current_version": ".".join(map(str, cur)) if cur else None,
             "denominator": len(results),   # always reported — never a bare count (gh#2045)
             "pass": len(results) - len(fails) - len(unavail),
@@ -158,7 +302,10 @@ def main():
         print("=" * 62)
         print("DEPRECATION REMOVAL CHECK — registry removal-version vs current")
         print("=" * 62)
-        print(f"\n  current version : {'.'.join(map(str, cur)) if cur else 'UNREADABLE'}")
+        print(f"\n  registry        : {registry}")
+        print(f"  registry source : {strategy}")
+        print(f"  version source  : {version_json}")
+        print(f"  current version : {'.'.join(map(str, cur)) if cur else 'UNREADABLE'}")
         print(f"  registry rows   : {len(results)}")
         print(f"  PASS {len(results)-len(fails)-len(unavail)}  FAIL {len(fails)}  UNAVAILABLE {len(unavail)}\n")
         for r in results:
@@ -168,6 +315,33 @@ def main():
             print("\n  A removal version that has passed with the row still open is not a\n"
                   "  schedule slip — it is an unactuated rule. Remove the artifact and mark\n"
                   "  the row Removed, or re-baseline the version with a stated reason.")
+        if unavail or not results:
+            print("\n  This run did not measure its whole population, so it certifies\n"
+                  "  nothing about the rows it could not classify. Exit 2, not 0.")
+
+    # UNAVAILABLE first, and BEFORE --advisory. The registry was reachable, so the earlier
+    # exit is not the one that fires here; what is unavailable is the measurement of one or
+    # more rows. Reported on stderr with the `UNAVAILABLE:` discriminator because exit 2 is
+    # shared with argparse's usage error (L1432) and the code alone cannot be tested on.
+    if not results:
+        print(f"UNAVAILABLE: registry readable but 0 rows parsed at {registry}",
+              file=sys.stderr)
+        print("UNAVAILABLE: an empty denominator is not a clean population (gh#2045); "
+              "the row predicate may have drifted from the table format.", file=sys.stderr)
+        print(f"UNAVAILABLE: subject chosen by {strategy}", file=sys.stderr)
+        return 2
+    if unavail:
+        print(f"UNAVAILABLE: {len(unavail)} of {len(results)} registry rows could not be "
+              f"classified at {registry}", file=sys.stderr)
+        for r in unavail:
+            print(f"UNAVAILABLE: {r['id']} — {r['detail']}", file=sys.stderr)
+        if fails:
+            print(f"UNAVAILABLE: {len(fails)} row(s) also FAIL and are reported above; "
+                  "UNAVAILABLE takes the exit code because the population is "
+                  "only partly measured.", file=sys.stderr)
+        print(f"UNAVAILABLE: subject chosen by {strategy}", file=sys.stderr)
+        return 2
+
     if args.advisory:
         return 0
     return 1 if fails else 0

--- a/scripts/release_cadence_gap.py
+++ b/scripts/release_cadence_gap.py
@@ -42,6 +42,7 @@ Usage:
 Exit codes:
     0  cap HELD (or no binding intervals yet)
     1  cap BREACHED -- on every output path, --json included
+    2  source UNAVAILABLE -- the declared repository was not measured
 """
 import argparse
 import json
@@ -112,55 +113,12 @@ def _default_repo():
     return None, "UNAVAILABLE:no canonical repo found by explicit input, own repo root, or sibling aget/"
 
 
-def resolve_source(cli_repo=None):
-    """Resolve the subject across EVERY input channel, with one rule.
-
-    Precedence: explicit --repo > explicit AGET_CANONICAL_ROOT > discovery.
-
-    v3.32 Phase-3 review repair. The prior version gated only the environment
-    variable. `--repo` defaulted to the module-level CANONICAL computed at IMPORT
-    time, so an explicit `--repo` never reached this gate at all:
-
-      * an unresolvable --repo fell through to _tags(), which raised and exited 1
-        with EMPTY stdout -- indistinguishable from BREACHED, which is the exact
-        conflation this module exists to end (findings 1, 2);
-      * discovery had already run at import regardless of --repo (finding 3);
-      * and source_strategy reported how DISCOVERY resolved even when --repo chose
-        the subject, so the tool measured one repository and disclosed a different
-        strategy for choosing it (finding 4) -- a false headline claim, since this
-        module promises source DISCLOSURE, not merely source selection.
-
-    Fixing only --repo would repeat the original error one channel over, so every
-    channel now returns through this one function.
-    """
-    import os
-    import pathlib as _pl
-
-    if cli_repo is not None and cli_repo != "":
-        if (_pl.Path(cli_repo) / ".git").exists():
-            return str(cli_repo), "explicit:--repo"
-        return None, (f"UNAVAILABLE:explicit --repo={cli_repo!r} is not a git repository "
-                      "(rejected, no fallback applied)")
-
-    env = os.environ.get("AGET_CANONICAL_ROOT")
-    if env is not None and env != "":
-        if (_pl.Path(env) / ".git").exists():
-            return env, "explicit:AGET_CANONICAL_ROOT"
-        return None, (f"UNAVAILABLE:explicit AGET_CANONICAL_ROOT={env!r} is not a git repository "
-                      "(rejected, no fallback applied)")
-
-    here = _pl.Path(__file__).resolve().parent.parent
-    if (here / ".git").exists():
-        return str(here), "discovered:own-repo-root"
-    sibling = here.parent / "aget"
-    if (sibling / ".git").exists():
-        return str(sibling), "discovered:sibling-aget"
-    return None, "UNAVAILABLE:no canonical repo found by explicit input, own repo root, or sibling aget/"
-
-
-CANONICAL, CANONICAL_STRATEGY = _default_repo()
 CAP_SATURDAYS = 3               # R-REL-CAD-007 parameter (principal-tunable, D-RP-7)
 POLICY_IN_FORCE = "2026-06-26"  # commit that introduced R-REL-CAD-007
+
+
+class RepositoryUnavailable(RuntimeError):
+    """The declared repository could not be measured."""
 
 
 def _tags(repo):
@@ -171,7 +129,7 @@ def _tags(repo):
          "refs/tags"],
         capture_output=True, text=True)
     if out.returncode != 0:
-        raise SystemExit(f"cannot read tags from {repo}: {out.stderr.strip()}")
+        raise RepositoryUnavailable(f"cannot read tags from {repo}: {out.stderr.strip()}")
 
     rows, skipped = [], []
     for line in out.stdout.splitlines():
@@ -230,7 +188,19 @@ def _saturdays_between(a, b):
     return n
 
 
-def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE, strategy=None):
+def compute(repo=None, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE,
+            source_strategy=None):
+    if repo is None:
+        repo, resolved_strategy = _default_repo()
+        if repo is None:
+            raise RepositoryUnavailable(resolved_strategy.split("UNAVAILABLE:", 1)[-1])
+        if source_strategy is None:
+            source_strategy = resolved_strategy
+    elif source_strategy is None:
+        # Library callers that supply a repository are explicit too. The CLI
+        # passes its more specific channel name below.
+        source_strategy = "explicit:compute(repo)"
+
     rows, skipped = _tags(repo)
     in_force_date = datetime.fromisoformat(in_force).date()
 
@@ -258,7 +228,7 @@ def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE, strateg
         "cap_saturdays": cap,
         "policy_in_force": in_force,
         "source_repo": repo,
-        "source_strategy": strategy if strategy is not None else CANONICAL_STRATEGY,
+        "source_strategy": source_strategy,
         "tags_considered": len(rows),
         "tags_skipped": skipped,
         "intervals_total": len(intervals),
@@ -273,16 +243,24 @@ def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE, strateg
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--repo", default=None,
-                    help="canonical public repo path (explicit; rejected loudly if not a git repo)")
+    # None is intentional: it preserves whether the operator supplied --repo.
+    # Defaulting this argument to a discovered path made the explicit and
+    # discovered channels indistinguishable and caused the v3.32 review defect.
+    ap.add_argument("--repo", default=None, help="canonical public repo path")
     ap.add_argument("--cap", type=int, default=CAP_SATURDAYS)
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--all", action="store_true", help="print every interval, not just binding ones")
     args = ap.parse_args()
 
-    # Every channel resolves here, after parsing. Resolving at import time is what
-    # let --repo bypass the gate entirely.
-    repo, strategy = resolve_source(args.repo)
+    # Resolve only after argparse establishes whether --repo was supplied.
+    # Explicit CLI selection outranks environment/discovery; the existing
+    # AGET_CANONICAL_ROOT -> own-root -> sibling precedence remains unchanged
+    # when --repo is absent.
+    if args.repo is not None:
+        repo = args.repo
+        source_strategy = "explicit:--repo"
+    else:
+        repo, source_strategy = _default_repo()
 
     # UNAVAILABLE gate (v3.32 AC-3). Fires BEFORE any measurement, because a
     # measurement of a substituted subject is worse than no measurement.
@@ -290,20 +268,40 @@ def main():
     # cadence is BREACHED"; 2 means "never read the declared subject at all".
     # Collapsing them to "nonzero" is the conflation this repair exists to end.
     if repo is None:
-        msg = strategy.split("UNAVAILABLE:", 1)[-1]
+        msg = source_strategy.split("UNAVAILABLE:", 1)[-1]
         if args.json:
             print(json.dumps({
                 "metric": "AGET-Release_gap (Saturdays between consecutive public releases)",
                 "status": "UNAVAILABLE",
                 "source_repo": None,
-                "source_strategy": strategy,
+                "source_strategy": source_strategy,
                 "reason": msg,
             }, indent=2))
         else:
             print(f"UNAVAILABLE: {msg}", file=sys.stderr)
         return 2
 
-    r = compute(repo=repo, cap=args.cap, strategy=strategy)
+    try:
+        r = compute(repo=repo, cap=args.cap, source_strategy=source_strategy)
+    except RepositoryUnavailable as exc:
+        if args.repo is not None:
+            unavailable_strategy = (
+                f"UNAVAILABLE:explicit --repo={args.repo!r} could not be read "
+                "(rejected, no fallback applied)"
+            )
+        else:
+            unavailable_strategy = f"UNAVAILABLE:{source_strategy} could not be read"
+        if args.json:
+            print(json.dumps({
+                "metric": "AGET-Release_gap (Saturdays between consecutive public releases)",
+                "status": "UNAVAILABLE",
+                "source_repo": None,
+                "source_strategy": unavailable_strategy,
+                "reason": str(exc),
+            }, indent=2))
+        else:
+            print(f"UNAVAILABLE: {exc}", file=sys.stderr)
+        return 2
 
     if args.json:
         print(json.dumps(r, indent=2))

--- a/scripts/release_cadence_gap.py
+++ b/scripts/release_cadence_gap.py
@@ -67,28 +67,52 @@ def _default_repo():
       1. AGET_CANONICAL_ROOT           -- explicit operator override
       2. this file's own repo root     -- the common case: we ARE canonical
       3. ../aget sibling               -- the fleet-checkout layout
+
+    REPAIRED 2026-08-21 (v3.32 AC-3). The ladder above was correct; its FAILURE
+    MODE was not. An explicit AGET_CANONICAL_ROOT that does not resolve fell
+    silently through to rule 2 and the tool measured a DIFFERENT repository,
+    reported it as the canonical public repo, and exited 0.
+
+    Measured on the shipped blob 4ac6b576268b31d4ea580ea12293d7a8bbc95d1e:
+      AGET_CANONICAL_ROOT=/nonexistent ... --json  ->  exit 0
+      "source_repo": "<whatever repo the script happened to live in>"
+      disclosure of the rejected input: none
+
+    An operator who names a subject and is silently given another subject gets a
+    confident answer about the wrong thing. That is worse than an error.
+
+    Two rules, and they are different in kind:
+      - An explicit input that does not resolve is UNAVAILABLE (exit 2). It is
+        never silently replaced, and never conflated with FAIL (exit 1), which
+        means "the subject was read and the cadence is breached."
+      - Discovery (rules 2 and 3) applies only when NO explicit input was given.
+
+    Returns (repo, strategy). The strategy is disclosed in output so a reader can
+    always tell which rule won -- source disclosure, not just source selection.
     """
     import os
     import pathlib
 
     env = os.environ.get("AGET_CANONICAL_ROOT")
-    if env and (pathlib.Path(env) / ".git").exists():
-        return env
+    if env is not None and env != "":
+        if (pathlib.Path(env) / ".git").exists():
+            return env, "explicit:AGET_CANONICAL_ROOT"
+        # Explicit and unresolvable. Do NOT fall through: the operator named a
+        # subject, and substituting another one is the defect being repaired.
+        return None, f"UNAVAILABLE:explicit AGET_CANONICAL_ROOT={env!r} is not a git repository (rejected, no fallback applied)"
 
     here = pathlib.Path(__file__).resolve().parent.parent
     if (here / ".git").exists():
-        return str(here)
+        return str(here), "discovered:own-repo-root"
 
     sibling = here.parent / "aget"
     if (sibling / ".git").exists():
-        return str(sibling)
+        return str(sibling), "discovered:sibling-aget"
 
-    # Absence is reported by the caller as UNRESOLVED, distinct from a breached
-    # cadence -- the disclosed exit-1 ambiguity this release shipped with.
-    return str(here)
+    return None, "UNAVAILABLE:no canonical repo found by explicit input, own repo root, or sibling aget/"
 
 
-CANONICAL = _default_repo()
+CANONICAL, CANONICAL_STRATEGY = _default_repo()
 CAP_SATURDAYS = 3               # R-REL-CAD-007 parameter (principal-tunable, D-RP-7)
 POLICY_IN_FORCE = "2026-06-26"  # commit that introduced R-REL-CAD-007
 
@@ -167,6 +191,7 @@ def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE):
         "cap_saturdays": cap,
         "policy_in_force": in_force,
         "source_repo": repo,
+        "source_strategy": CANONICAL_STRATEGY,
         "tags_considered": len(rows),
         "tags_skipped": skipped,
         "intervals_total": len(intervals),
@@ -187,6 +212,25 @@ def main():
     ap.add_argument("--all", action="store_true", help="print every interval, not just binding ones")
     args = ap.parse_args()
 
+    # UNAVAILABLE gate (v3.32 AC-3). Fires BEFORE any measurement, because a
+    # measurement of a substituted subject is worse than no measurement.
+    # Exit 2 is deliberately distinct from exit 1: 1 means "read the subject,
+    # cadence is BREACHED"; 2 means "never read the declared subject at all".
+    # Collapsing them to "nonzero" is the conflation this repair exists to end.
+    if args.repo is None:
+        msg = CANONICAL_STRATEGY.split("UNAVAILABLE:", 1)[-1]
+        if args.json:
+            print(json.dumps({
+                "metric": "AGET-Release_gap (Saturdays between consecutive public releases)",
+                "status": "UNAVAILABLE",
+                "source_repo": None,
+                "source_strategy": CANONICAL_STRATEGY,
+                "reason": msg,
+            }, indent=2))
+        else:
+            print(f"UNAVAILABLE: {msg}", file=sys.stderr)
+        return 2
+
     r = compute(repo=args.repo, cap=args.cap)
 
     if args.json:
@@ -199,6 +243,14 @@ def main():
     print(f"{r['metric']}")
     print(f"  requirement : {r['requirement']} — cap {r['cap_saturdays']} consecutive Saturdays")
     print(f"  source      : {r['source_repo']} annotated tags ({r['tags_considered']} releases)")
+    # Source SELECTION without source STRATEGY is the half-disclosure this module's
+    # own docstring forbids: "a reader can always tell which rule won". Both --json
+    # paths carried source_strategy from the start; this path, the one an operator
+    # actually reads, printed only the path. An explicitly-named subject and a
+    # discovered one rendered identically, which is precisely the distinction the
+    # 2026-08-21 repair exists to make visible. Found by rehearsing the shipped
+    # instrument end to end, 2026-08-23.
+    print(f"  resolved by : {r['source_strategy']}")
     print(f"  in force    : {r['policy_in_force']} — {r['intervals_binding']} binding "
           f"of {r['intervals_total']} intervals")
     if r["tags_skipped"]:

--- a/scripts/release_cadence_gap.py
+++ b/scripts/release_cadence_gap.py
@@ -138,9 +138,30 @@ def _tags(repo):
         if otype != "tag" or not tdate:
             skipped.append({"tag": name, "reason": "lightweight tag — no tag object to date"})
             continue
-        rows.append((name, datetime.fromisoformat(tdate)))
+        rows.append((name, _parse_tagger_date(tdate)))
     rows.sort(key=lambda r: r[1])
     return rows, skipped
+
+
+
+def _parse_tagger_date(value):
+    """Parse a git taggerdate across Python versions.
+
+    Python 3.11 accepts a terminal `Z` and colon-less UTC offsets; 3.10 does not
+    and raises ValueError. git emits either form depending on log.date / config,
+    so the shipped script parsed fine on 3.11+ and died on 3.10 -- exiting 1 with
+    empty stdout, which the caller could not distinguish from a real BREACHED
+    result. Normalizing here keeps the version difference out of every call site.
+    """
+    s = (value or "").strip()
+    if not s:
+        raise ValueError("empty taggerdate")
+    if s.endswith(("Z", "z")):
+        s = s[:-1] + "+00:00"
+    # colon-less offset: "+0000" / "-0730" -> "+00:00" / "-07:30"
+    if len(s) >= 5 and s[-5] in "+-" and s[-3] != ":":
+        s = s[:-2] + ":" + s[-2:]
+    return datetime.fromisoformat(s)
 
 
 def _is_release_tag(name):

--- a/scripts/release_cadence_gap.py
+++ b/scripts/release_cadence_gap.py
@@ -112,6 +112,52 @@ def _default_repo():
     return None, "UNAVAILABLE:no canonical repo found by explicit input, own repo root, or sibling aget/"
 
 
+def resolve_source(cli_repo=None):
+    """Resolve the subject across EVERY input channel, with one rule.
+
+    Precedence: explicit --repo > explicit AGET_CANONICAL_ROOT > discovery.
+
+    v3.32 Phase-3 review repair. The prior version gated only the environment
+    variable. `--repo` defaulted to the module-level CANONICAL computed at IMPORT
+    time, so an explicit `--repo` never reached this gate at all:
+
+      * an unresolvable --repo fell through to _tags(), which raised and exited 1
+        with EMPTY stdout -- indistinguishable from BREACHED, which is the exact
+        conflation this module exists to end (findings 1, 2);
+      * discovery had already run at import regardless of --repo (finding 3);
+      * and source_strategy reported how DISCOVERY resolved even when --repo chose
+        the subject, so the tool measured one repository and disclosed a different
+        strategy for choosing it (finding 4) -- a false headline claim, since this
+        module promises source DISCLOSURE, not merely source selection.
+
+    Fixing only --repo would repeat the original error one channel over, so every
+    channel now returns through this one function.
+    """
+    import os
+    import pathlib as _pl
+
+    if cli_repo is not None and cli_repo != "":
+        if (_pl.Path(cli_repo) / ".git").exists():
+            return str(cli_repo), "explicit:--repo"
+        return None, (f"UNAVAILABLE:explicit --repo={cli_repo!r} is not a git repository "
+                      "(rejected, no fallback applied)")
+
+    env = os.environ.get("AGET_CANONICAL_ROOT")
+    if env is not None and env != "":
+        if (_pl.Path(env) / ".git").exists():
+            return env, "explicit:AGET_CANONICAL_ROOT"
+        return None, (f"UNAVAILABLE:explicit AGET_CANONICAL_ROOT={env!r} is not a git repository "
+                      "(rejected, no fallback applied)")
+
+    here = _pl.Path(__file__).resolve().parent.parent
+    if (here / ".git").exists():
+        return str(here), "discovered:own-repo-root"
+    sibling = here.parent / "aget"
+    if (sibling / ".git").exists():
+        return str(sibling), "discovered:sibling-aget"
+    return None, "UNAVAILABLE:no canonical repo found by explicit input, own repo root, or sibling aget/"
+
+
 CANONICAL, CANONICAL_STRATEGY = _default_repo()
 CAP_SATURDAYS = 3               # R-REL-CAD-007 parameter (principal-tunable, D-RP-7)
 POLICY_IN_FORCE = "2026-06-26"  # commit that introduced R-REL-CAD-007
@@ -184,7 +230,7 @@ def _saturdays_between(a, b):
     return n
 
 
-def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE):
+def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE, strategy=None):
     rows, skipped = _tags(repo)
     in_force_date = datetime.fromisoformat(in_force).date()
 
@@ -212,7 +258,7 @@ def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE):
         "cap_saturdays": cap,
         "policy_in_force": in_force,
         "source_repo": repo,
-        "source_strategy": CANONICAL_STRATEGY,
+        "source_strategy": strategy if strategy is not None else CANONICAL_STRATEGY,
         "tags_considered": len(rows),
         "tags_skipped": skipped,
         "intervals_total": len(intervals),
@@ -227,32 +273,37 @@ def compute(repo=CANONICAL, cap=CAP_SATURDAYS, in_force=POLICY_IN_FORCE):
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--repo", default=CANONICAL, help="canonical public repo path")
+    ap.add_argument("--repo", default=None,
+                    help="canonical public repo path (explicit; rejected loudly if not a git repo)")
     ap.add_argument("--cap", type=int, default=CAP_SATURDAYS)
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--all", action="store_true", help="print every interval, not just binding ones")
     args = ap.parse_args()
+
+    # Every channel resolves here, after parsing. Resolving at import time is what
+    # let --repo bypass the gate entirely.
+    repo, strategy = resolve_source(args.repo)
 
     # UNAVAILABLE gate (v3.32 AC-3). Fires BEFORE any measurement, because a
     # measurement of a substituted subject is worse than no measurement.
     # Exit 2 is deliberately distinct from exit 1: 1 means "read the subject,
     # cadence is BREACHED"; 2 means "never read the declared subject at all".
     # Collapsing them to "nonzero" is the conflation this repair exists to end.
-    if args.repo is None:
-        msg = CANONICAL_STRATEGY.split("UNAVAILABLE:", 1)[-1]
+    if repo is None:
+        msg = strategy.split("UNAVAILABLE:", 1)[-1]
         if args.json:
             print(json.dumps({
                 "metric": "AGET-Release_gap (Saturdays between consecutive public releases)",
                 "status": "UNAVAILABLE",
                 "source_repo": None,
-                "source_strategy": CANONICAL_STRATEGY,
+                "source_strategy": strategy,
                 "reason": msg,
             }, indent=2))
         else:
             print(f"UNAVAILABLE: {msg}", file=sys.stderr)
         return 2
 
-    r = compute(repo=args.repo, cap=args.cap)
+    r = compute(repo=repo, cap=args.cap, strategy=strategy)
 
     if args.json:
         print(json.dumps(r, indent=2))

--- a/tests/test_release_cadence_gap_source_contract.py
+++ b/tests/test_release_cadence_gap_source_contract.py
@@ -82,6 +82,14 @@ def _payload_of(r, expect_exit):
         raise AssertionError(f"exit {r.returncode} with non-JSON stdout: {e}\nstdout:\n{r.stdout}") from None
 
 
+def _run_argv(argv):
+    """Run the script with argv, inheriting a clean environment."""
+    env = dict(os.environ)
+    env.pop("AGET_CANONICAL_ROOT", None)
+    return subprocess.run([sys.executable, str(SCRIPT), *argv],
+                          capture_output=True, text=True, env=env)
+
+
 def test_utc_z_taggerdate_parses_deterministically():
     """Regression for the Python 3.10 CI failure. Deterministic: the tag date is
     pinned via env, so this asserts parsing, not the clock."""
@@ -261,4 +269,78 @@ def test_human_output_discloses_strategy_not_only_path(tmp_path):
 
     assert "explicit:" not in discovered.stdout, (
         "a discovered subject must not render as an explicitly-named one"
+    )
+
+
+# --- CLI channel (--repo) -----------------------------------------------------
+# Added v3.32 Phase 3. The independent review falsified four propositions against
+# the --repo channel and noted the cause: "the cadence source-contract tests do not
+# exercise either valid or invalid explicit --repo input". Five green matrix cells
+# passed a payload whose headline claim was false through its own CLI flag. Every
+# channel is now covered, because fixing only the named instance is how this
+# defect reached a review in the first place.
+
+def test_invalid_explicit_repo_is_unavailable_not_breach():
+    """F1+F2: an unresolvable --repo is UNAVAILABLE (2), never BREACHED (1)."""
+    r = _run_argv(["--repo", "/nonexistent/xyz", "--json"])
+    assert r.returncode == EXIT_UNAVAILABLE, (
+        f"expected exit 2, got {r.returncode}. Exit 1 here is indistinguishable from "
+        f"BREACHED, which is the conflation this module exists to end.\n{r.stdout}{r.stderr}"
+    )
+    payload = _payload_of(r, EXIT_UNAVAILABLE)
+    assert payload["source_repo"] is None, "a rejected subject must not be substituted"
+    assert "--repo" in payload["source_strategy"], "the rejection must name the channel"
+
+
+def test_invalid_explicit_repo_emits_json_not_empty_stdout():
+    """F2 corollary: the failure is a verdict, not a crash."""
+    r = _run_argv(["--repo", "/nonexistent/xyz", "--json"])
+    assert r.stdout.strip(), "exit with empty stdout is a crash wearing a verdict's exit code"
+    json.loads(r.stdout)
+
+
+def test_valid_explicit_repo_discloses_the_channel_that_selected_it(tmp_path):
+    """F4: the disclosed strategy must be the strategy that chose the subject.
+
+    The shipped defect reported 'discovered:own-repo-root' for a repo supplied via
+    --repo -- measuring one repository and disclosing a different basis for it.
+    """
+    repo = tmp_path / "r"
+    (repo).mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    for k, v in (("user.email", "f@example.com"), ("user.name", "F")):
+        subprocess.run(["git", "-C", str(repo), "config", k, v], check=True)
+    (repo / "s.txt").write_text("s\n")
+    subprocess.run(["git", "-C", str(repo), "add", "s.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "s"], check=True)
+    subprocess.run(["git", "-C", str(repo), "tag", "-a", "v3.31.0", "-m", "r"], check=True)
+
+    r = _run_argv(["--repo", str(repo), "--json"])
+    payload = _breached_or_ok(r)
+    assert payload["source_repo"] == str(repo), "must measure the repo it was given"
+    assert payload["source_strategy"] == "explicit:--repo", (
+        f"disclosed strategy {payload['source_strategy']!r} is not the channel that "
+        "selected the subject -- source disclosure, not merely source selection"
+    )
+
+
+def test_explicit_repo_outranks_environment(tmp_path):
+    """F3: discovery and env must not run when --repo was given."""
+    repo = tmp_path / "r2"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    for k, v in (("user.email", "f@example.com"), ("user.name", "F")):
+        subprocess.run(["git", "-C", str(repo), "config", k, v], check=True)
+    (repo / "s.txt").write_text("s\n")
+    subprocess.run(["git", "-C", str(repo), "add", "s.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "s"], check=True)
+    subprocess.run(["git", "-C", str(repo), "tag", "-a", "v3.31.0", "-m", "r"], check=True)
+
+    env = dict(os.environ)
+    env["AGET_CANONICAL_ROOT"] = "/nonexistent/should-be-ignored"
+    r = subprocess.run([sys.executable, str(SCRIPT), "--repo", str(repo), "--json"],
+                       capture_output=True, text=True, env=env)
+    payload = _breached_or_ok(r)
+    assert payload["source_strategy"] == "explicit:--repo", (
+        "an explicit --repo must outrank the environment variable"
     )

--- a/tests/test_release_cadence_gap_source_contract.py
+++ b/tests/test_release_cadence_gap_source_contract.py
@@ -1,0 +1,200 @@
+"""AC-3 source-resolution contract — v3.32 prepared public delta.
+
+Falsifiers for the defect measured on shipped blob
+4ac6b576268b31d4ea580ea12293d7a8bbc95d1e: an explicit AGET_CANONICAL_ROOT that
+does not resolve was silently discarded, a DIFFERENT repository was measured and
+reported as canonical, and the process exited 0.
+
+Each test below was demonstrated RED against that exact blob before being
+accepted (L1425: a green suite cannot discharge a falsifier it does not encode).
+
+The tests run the script as a SUBPROCESS on purpose. The defect lives in
+module-level resolution (`CANONICAL, CANONICAL_STRATEGY = _default_repo()`), so
+importing the module would bind the strategy once and make the environment
+variable untestable.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "release_cadence_gap.py"
+
+EXIT_OK, EXIT_BREACHED, EXIT_UNAVAILABLE = 0, 1, 2
+
+
+def _run(env_root, *args):
+    env = dict(os.environ)
+    if env_root is None:
+        env.pop("AGET_CANONICAL_ROOT", None)
+    else:
+        env["AGET_CANONICAL_ROOT"] = env_root
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_rejected_explicit_root_is_unavailable_not_success():
+    """RED on 4ac6b576: returned 0. An operator-named subject that cannot be
+    read must never be reported as a successful measurement."""
+    r = _run("/nonexistent/xyz", "--json")
+    assert r.returncode == EXIT_UNAVAILABLE, (
+        f"expected UNAVAILABLE({EXIT_UNAVAILABLE}), got {r.returncode}"
+    )
+
+
+def test_rejected_explicit_root_is_not_conflated_with_breach():
+    """UNAVAILABLE(2) and BREACHED(1) are different claims. 'Non-zero' is not an
+    acceptable contract -- collapsing them is the conflation this repair ends."""
+    r = _run("/nonexistent/xyz", "--json")
+    assert r.returncode != EXIT_BREACHED
+
+
+def test_rejected_explicit_root_discloses_the_rejection():
+    """RED on 4ac6b576: disclosed nothing. Source disclosure, not just source
+    selection -- a reader must be able to tell which rule won."""
+    r = _run("/nonexistent/xyz", "--json")
+    payload = json.loads(r.stdout)
+    assert payload["status"] == "UNAVAILABLE"
+    assert "AGET_CANONICAL_ROOT" in payload["source_strategy"]
+    assert "no fallback applied" in payload["source_strategy"]
+
+
+def test_rejected_explicit_root_never_substitutes_another_subject():
+    """The sharpest form of the defect: 4ac6b576 reported a throwaway scratch
+    directory as the canonical public repo and exited 0."""
+    r = _run("/nonexistent/xyz", "--json")
+    payload = json.loads(r.stdout)
+    assert payload["source_repo"] is None, (
+        f"a rejected explicit input must not be replaced; got {payload['source_repo']!r}"
+    )
+
+
+def test_valid_explicit_root_still_measures_and_discloses_strategy():
+    """Positive polarity. A repair that only ever returns UNAVAILABLE would pass
+    every negative test above and be useless.
+
+    Gate 0 repair (2026-08-22): this computed the repo root at `parents[3]`, which
+    from the prepared-delta harness was `docs/` -- not a git repository, so the
+    test handed the script a non-repository as its EXPLICIT root, the script
+    correctly rejected it, and the positive polarity was never exercised: the test
+    was asserting the negative case while claiming to prove the positive one.
+    Relocated to `tests/` for v3.32 publication, the repo root is `parents[1]`.
+    The `.git` assertion below is what makes a wrong depth fail loudly instead of
+    silently degrading back into the negative case.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    assert (repo_root / ".git").exists(), (
+        f"fixture cannot locate a git repository at {repo_root}; the positive polarity "
+        "must not silently degrade into the negative one again"
+    )
+    repo = str(repo_root)
+    r = _run(repo, "--json")
+    assert r.returncode in (EXIT_OK, EXIT_BREACHED), r.stdout
+    payload = json.loads(r.stdout)
+    assert payload["source_strategy"] == "explicit:AGET_CANONICAL_ROOT"
+    assert payload["source_repo"] == repo
+
+
+def test_absent_explicit_input_still_discovers(tmp_path):
+    """Discovery is only disabled when an explicit input was GIVEN and rejected.
+    With no explicit input, rules 2 and 3 must behave exactly as before.
+
+    Gate 0 repair (2026-08-22): discovery rules 2 and 3 are DEPTH-DEPENDENT by
+    design -- the script resolves `__file__.parent.parent` as its own repo root.
+    Run from the staging tree at `docs/prepared/v3.32/scripts/`, that resolves to
+    `docs/prepared/v3.32/`, and the sibling probe to `docs/prepared/aget/`; neither
+    exists, so the rule can only ever return UNAVAILABLE. The script was never
+    wrong -- the fixture measured it at a depth it will never run at. Verified
+    2026-08-22: the same file at `<repo>/scripts/` exits 0 with
+    `discovered:own-repo-root`. So the fixture now runs it at LANDING depth, which
+    is the tree that ships.
+    """
+    landing = tmp_path / "repo"
+    (landing / "scripts").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(landing)], check=True)
+    for k, v in (("user.email", "fixture@example.com"), ("user.name", "Fixture")):
+        subprocess.run(["git", "-C", str(landing), "config", k, v], check=True)
+    (landing / "seed.txt").write_text("seed\n")
+    subprocess.run(["git", "-C", str(landing), "add", "seed.txt"], check=True)
+    subprocess.run(["git", "-C", str(landing), "commit", "-qm", "seed"], check=True)
+    subprocess.run(["git", "-C", str(landing), "tag", "-a", "v3.31.0", "-m", "r"], check=True)
+
+    landed = landing / "scripts" / SCRIPT.name
+    landed.write_bytes(SCRIPT.read_bytes())
+
+    env = dict(os.environ)
+    env.pop("AGET_CANONICAL_ROOT", None)
+    r = subprocess.run(
+        [sys.executable, str(landed), "--json"], capture_output=True, text=True, env=env
+    )
+    assert r.returncode in (EXIT_OK, EXIT_BREACHED), r.stdout + r.stderr
+    payload = json.loads(r.stdout)
+    assert payload["source_strategy"] == "discovered:own-repo-root"
+    assert payload["source_repo"] == str(landing)
+
+
+def test_staged_depth_is_unavailable_and_says_so_rather_than_substituting(tmp_path):
+    """Negative polarity of the repair above, and the reason it is not a papered-over
+    failure: at a depth where discovery genuinely cannot resolve, the script must
+    return UNAVAILABLE and name that -- never substitute a different repository.
+    That is the original AC-3 defect, asserted here at the staging depth itself.
+    """
+    orphan = tmp_path / "nowhere" / "scripts"
+    orphan.mkdir(parents=True)
+    landed = orphan / SCRIPT.name
+    landed.write_bytes(SCRIPT.read_bytes())
+
+    env = dict(os.environ)
+    env.pop("AGET_CANONICAL_ROOT", None)
+    r = subprocess.run(
+        [sys.executable, str(landed), "--json"], capture_output=True, text=True, env=env
+    )
+    assert r.returncode == EXIT_UNAVAILABLE
+    payload = json.loads(r.stdout)
+    assert payload["source_repo"] is None
+    assert payload["source_strategy"].startswith("UNAVAILABLE:")
+
+
+def test_human_output_discloses_strategy_not_only_path(tmp_path):
+    """Both polarities on the path an operator actually reads.
+
+    Found 2026-08-23 by rehearsing the shipped instrument end to end. Both --json
+    paths carried `source_strategy` from the start; the default text path printed
+    only `source : <repo>`. So an explicitly-named subject and a discovered one
+    rendered IDENTICALLY -- which is exactly the distinction the 2026-08-21 repair
+    exists to make visible, absent from the output most people see.
+
+    The assertion that matters is not "the word appears" but "the two cases are
+    DISTINGUISHABLE". A disclosure that renders the same for both resolutions
+    discloses nothing, and would pass a naive substring check.
+    """
+    repo_root = Path(__file__).resolve().parents[1]
+    assert (repo_root / ".git").exists(), "fixture cannot locate a git repository"
+
+    explicit = _run(str(repo_root))
+    assert explicit.returncode in (EXIT_OK, EXIT_BREACHED), explicit.stdout
+    assert "explicit:AGET_CANONICAL_ROOT" in explicit.stdout, (
+        "human path does not say the subject was explicitly named:\n" + explicit.stdout
+    )
+
+    # Discovery polarity: a real repo with the script at landing depth (<repo>/scripts/).
+    land = tmp_path / "landing"
+    (land / "scripts").mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(land)], check=True)
+    (land / "scripts" / SCRIPT.name).write_text(SCRIPT.read_text())
+    env = dict(os.environ)
+    env.pop("AGET_CANONICAL_ROOT", None)
+    discovered = subprocess.run(
+        [sys.executable, str(land / "scripts" / SCRIPT.name)],
+        capture_output=True, text=True, env=env,
+    )
+    assert "discovered:own-repo-root" in discovered.stdout, (
+        "human path does not say the subject was discovered:\n" + discovered.stdout
+    )
+
+    assert "explicit:" not in discovered.stdout, (
+        "a discovered subject must not render as an explicitly-named one"
+    )

--- a/tests/test_release_cadence_gap_source_contract.py
+++ b/tests/test_release_cadence_gap_source_contract.py
@@ -36,6 +36,72 @@ def _run(env_root, *args):
     )
 
 
+def _breached_or_ok(r):
+    """An exit code alone cannot be read as a verdict.
+
+    EXIT_BREACHED is 1, and so is the exit code of almost any crash. The shipped
+    test asserted `returncode in (EXIT_OK, EXIT_BREACHED)` and then parsed stdout;
+    on Python 3.10 the script died in date parsing, exited 1 with EMPTY stdout, and
+    the assertion passed VACUOUSLY -- the real failure surfaced downstream as a
+    JSONDecodeError, one layer away from its cause.
+
+    So: exit 1 may be interpreted as a legitimate BREACHED result only when stdout
+    also carries non-empty, valid JSON. Otherwise it is a crash and is reported as
+    one, at the point it happened.
+    """
+    assert r.returncode in (EXIT_OK, EXIT_BREACHED), (
+        f"unexpected exit {r.returncode}\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+    assert r.stdout.strip(), (
+        f"exit {r.returncode} with EMPTY stdout is a crash, not a verdict "
+        f"(EXIT_BREACHED collides with a crash's exit 1)\nstderr:\n{r.stderr}"
+    )
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        raise AssertionError(
+            f"exit {r.returncode} with non-JSON stdout is a crash, not a verdict: {e}"
+            f"\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+        ) from None
+
+
+def _payload_of(r, expect_exit):
+    """Same discipline as `_breached_or_ok`, for the UNAVAILABLE polarity.
+
+    exit 2 is UNAVAILABLE and does NOT collide with a crash the way exit 1 does,
+    but the JSON requirement is identical: a verdict whose stdout is empty or
+    unparseable is a crash wearing a verdict's exit code.
+    """
+    assert r.returncode == expect_exit, (
+        f"expected exit {expect_exit}, got {r.returncode}\nstdout:\n{r.stdout}\nstderr:\n{r.stderr}"
+    )
+    assert r.stdout.strip(), f"exit {r.returncode} with EMPTY stdout\nstderr:\n{r.stderr}"
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"exit {r.returncode} with non-JSON stdout: {e}\nstdout:\n{r.stdout}") from None
+
+
+def test_utc_z_taggerdate_parses_deterministically():
+    """Regression for the Python 3.10 CI failure. Deterministic: the tag date is
+    pinned via env, so this asserts parsing, not the clock."""
+    from datetime import datetime, timezone
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("_rcg", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    expected = datetime(2026, 8, 15, 18, 29, 0, tzinfo=timezone.utc)
+    for form in ("2026-08-15T18:29:00Z", "2026-08-15T18:29:00+0000", "2026-08-15T18:29:00+00:00"):
+        got = mod._parse_tagger_date(form)
+        assert got == expected, f"{form!r} parsed to {got!r}, expected {expected!r}"
+
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        mod._parse_tagger_date("")
+
+
 def test_rejected_explicit_root_is_unavailable_not_success():
     """RED on 4ac6b576: returned 0. An operator-named subject that cannot be
     read must never be reported as a successful measurement."""
@@ -56,7 +122,7 @@ def test_rejected_explicit_root_discloses_the_rejection():
     """RED on 4ac6b576: disclosed nothing. Source disclosure, not just source
     selection -- a reader must be able to tell which rule won."""
     r = _run("/nonexistent/xyz", "--json")
-    payload = json.loads(r.stdout)
+    payload = _payload_of(r, EXIT_UNAVAILABLE)
     assert payload["status"] == "UNAVAILABLE"
     assert "AGET_CANONICAL_ROOT" in payload["source_strategy"]
     assert "no fallback applied" in payload["source_strategy"]
@@ -66,7 +132,7 @@ def test_rejected_explicit_root_never_substitutes_another_subject():
     """The sharpest form of the defect: 4ac6b576 reported a throwaway scratch
     directory as the canonical public repo and exited 0."""
     r = _run("/nonexistent/xyz", "--json")
-    payload = json.loads(r.stdout)
+    payload = _payload_of(r, EXIT_UNAVAILABLE)
     assert payload["source_repo"] is None, (
         f"a rejected explicit input must not be replaced; got {payload['source_repo']!r}"
     )
@@ -92,8 +158,7 @@ def test_valid_explicit_root_still_measures_and_discloses_strategy():
     )
     repo = str(repo_root)
     r = _run(repo, "--json")
-    assert r.returncode in (EXIT_OK, EXIT_BREACHED), r.stdout
-    payload = json.loads(r.stdout)
+    payload = _breached_or_ok(r)
     assert payload["source_strategy"] == "explicit:AGET_CANONICAL_ROOT"
     assert payload["source_repo"] == repo
 
@@ -130,8 +195,7 @@ def test_absent_explicit_input_still_discovers(tmp_path):
     r = subprocess.run(
         [sys.executable, str(landed), "--json"], capture_output=True, text=True, env=env
     )
-    assert r.returncode in (EXIT_OK, EXIT_BREACHED), r.stdout + r.stderr
-    payload = json.loads(r.stdout)
+    payload = _breached_or_ok(r)
     assert payload["source_strategy"] == "discovered:own-repo-root"
     assert payload["source_repo"] == str(landing)
 
@@ -153,7 +217,7 @@ def test_staged_depth_is_unavailable_and_says_so_rather_than_substituting(tmp_pa
         [sys.executable, str(landed), "--json"], capture_output=True, text=True, env=env
     )
     assert r.returncode == EXIT_UNAVAILABLE
-    payload = json.loads(r.stdout)
+    payload = _payload_of(r, EXIT_UNAVAILABLE)
     assert payload["source_repo"] is None
     assert payload["source_strategy"].startswith("UNAVAILABLE:")
 

--- a/tests/test_release_cadence_gap_source_contract.py
+++ b/tests/test_release_cadence_gap_source_contract.py
@@ -82,14 +82,6 @@ def _payload_of(r, expect_exit):
         raise AssertionError(f"exit {r.returncode} with non-JSON stdout: {e}\nstdout:\n{r.stdout}") from None
 
 
-def _run_argv(argv):
-    """Run the script with argv, inheriting a clean environment."""
-    env = dict(os.environ)
-    env.pop("AGET_CANONICAL_ROOT", None)
-    return subprocess.run([sys.executable, str(SCRIPT), *argv],
-                          capture_output=True, text=True, env=env)
-
-
 def test_utc_z_taggerdate_parses_deterministically():
     """Regression for the Python 3.10 CI failure. Deterministic: the tag date is
     pinned via env, so this asserts parsing, not the clock."""
@@ -169,6 +161,50 @@ def test_valid_explicit_root_still_measures_and_discloses_strategy():
     payload = _breached_or_ok(r)
     assert payload["source_strategy"] == "explicit:AGET_CANONICAL_ROOT"
     assert payload["source_repo"] == repo
+
+
+def test_invalid_explicit_repo_is_structured_unavailable_not_crash():
+    """The Phase-3 review falsifier: --repo used to exit 1 with empty stdout."""
+    declared = "/nonexistent/v332-explicit-repo"
+    r = _run(None, "--repo", declared, "--json")
+    payload = _payload_of(r, EXIT_UNAVAILABLE)
+
+    assert payload["status"] == "UNAVAILABLE"
+    assert payload["source_repo"] is None
+    assert "explicit --repo" in payload["source_strategy"]
+    assert declared in payload["source_strategy"]
+    assert "no fallback applied" in payload["source_strategy"]
+    assert payload["reason"]
+
+
+def test_invalid_explicit_repo_is_not_conflated_with_breach():
+    """UNAVAILABLE(2) stays distinct from the BREACHED(1) verdict namespace."""
+    r = _run(None, "--repo", "/nonexistent/v332-explicit-repo", "--json")
+    assert r.returncode == EXIT_UNAVAILABLE
+    assert r.returncode != EXIT_BREACHED
+    assert r.stdout.strip(), "structured UNAVAILABLE must not have empty stdout"
+
+
+def test_valid_explicit_repo_wins_over_environment_and_reports_cli_strategy():
+    """--repo is the measured subject even when the environment names another one."""
+    repo_root = Path(__file__).resolve().parents[1]
+    assert (repo_root / ".git").exists(), "fixture cannot locate a git repository"
+
+    r = _run(
+        "/nonexistent/environment-must-not-win",
+        "--repo", str(repo_root), "--json",
+    )
+    payload = _breached_or_ok(r)
+    assert payload["source_repo"] == str(repo_root)
+    assert payload["source_strategy"] == "explicit:--repo"
+
+
+def test_valid_explicit_repo_human_output_reports_cli_strategy():
+    """The operator-facing path must distinguish --repo from discovery."""
+    repo_root = Path(__file__).resolve().parents[1]
+    r = _run(None, "--repo", str(repo_root))
+    assert r.returncode in (EXIT_OK, EXIT_BREACHED), r.stderr
+    assert "resolved by : explicit:--repo" in r.stdout
 
 
 def test_absent_explicit_input_still_discovers(tmp_path):
@@ -269,78 +305,4 @@ def test_human_output_discloses_strategy_not_only_path(tmp_path):
 
     assert "explicit:" not in discovered.stdout, (
         "a discovered subject must not render as an explicitly-named one"
-    )
-
-
-# --- CLI channel (--repo) -----------------------------------------------------
-# Added v3.32 Phase 3. The independent review falsified four propositions against
-# the --repo channel and noted the cause: "the cadence source-contract tests do not
-# exercise either valid or invalid explicit --repo input". Five green matrix cells
-# passed a payload whose headline claim was false through its own CLI flag. Every
-# channel is now covered, because fixing only the named instance is how this
-# defect reached a review in the first place.
-
-def test_invalid_explicit_repo_is_unavailable_not_breach():
-    """F1+F2: an unresolvable --repo is UNAVAILABLE (2), never BREACHED (1)."""
-    r = _run_argv(["--repo", "/nonexistent/xyz", "--json"])
-    assert r.returncode == EXIT_UNAVAILABLE, (
-        f"expected exit 2, got {r.returncode}. Exit 1 here is indistinguishable from "
-        f"BREACHED, which is the conflation this module exists to end.\n{r.stdout}{r.stderr}"
-    )
-    payload = _payload_of(r, EXIT_UNAVAILABLE)
-    assert payload["source_repo"] is None, "a rejected subject must not be substituted"
-    assert "--repo" in payload["source_strategy"], "the rejection must name the channel"
-
-
-def test_invalid_explicit_repo_emits_json_not_empty_stdout():
-    """F2 corollary: the failure is a verdict, not a crash."""
-    r = _run_argv(["--repo", "/nonexistent/xyz", "--json"])
-    assert r.stdout.strip(), "exit with empty stdout is a crash wearing a verdict's exit code"
-    json.loads(r.stdout)
-
-
-def test_valid_explicit_repo_discloses_the_channel_that_selected_it(tmp_path):
-    """F4: the disclosed strategy must be the strategy that chose the subject.
-
-    The shipped defect reported 'discovered:own-repo-root' for a repo supplied via
-    --repo -- measuring one repository and disclosing a different basis for it.
-    """
-    repo = tmp_path / "r"
-    (repo).mkdir()
-    subprocess.run(["git", "init", "-q", str(repo)], check=True)
-    for k, v in (("user.email", "f@example.com"), ("user.name", "F")):
-        subprocess.run(["git", "-C", str(repo), "config", k, v], check=True)
-    (repo / "s.txt").write_text("s\n")
-    subprocess.run(["git", "-C", str(repo), "add", "s.txt"], check=True)
-    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "s"], check=True)
-    subprocess.run(["git", "-C", str(repo), "tag", "-a", "v3.31.0", "-m", "r"], check=True)
-
-    r = _run_argv(["--repo", str(repo), "--json"])
-    payload = _breached_or_ok(r)
-    assert payload["source_repo"] == str(repo), "must measure the repo it was given"
-    assert payload["source_strategy"] == "explicit:--repo", (
-        f"disclosed strategy {payload['source_strategy']!r} is not the channel that "
-        "selected the subject -- source disclosure, not merely source selection"
-    )
-
-
-def test_explicit_repo_outranks_environment(tmp_path):
-    """F3: discovery and env must not run when --repo was given."""
-    repo = tmp_path / "r2"
-    repo.mkdir()
-    subprocess.run(["git", "init", "-q", str(repo)], check=True)
-    for k, v in (("user.email", "f@example.com"), ("user.name", "F")):
-        subprocess.run(["git", "-C", str(repo), "config", k, v], check=True)
-    (repo / "s.txt").write_text("s\n")
-    subprocess.run(["git", "-C", str(repo), "add", "s.txt"], check=True)
-    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "s"], check=True)
-    subprocess.run(["git", "-C", str(repo), "tag", "-a", "v3.31.0", "-m", "r"], check=True)
-
-    env = dict(os.environ)
-    env["AGET_CANONICAL_ROOT"] = "/nonexistent/should-be-ignored"
-    r = subprocess.run([sys.executable, str(SCRIPT), "--repo", str(repo), "--json"],
-                       capture_output=True, text=True, env=env)
-    payload = _breached_or_ok(r)
-    assert payload["source_strategy"] == "explicit:--repo", (
-        "an explicit --repo must outrank the environment variable"
     )


### PR DESCRIPTION
Two repairs to controls that report on releases. Both failed at their shipped public subjects in v3.31.1.

## What this fixes

**The cadence check answered about the wrong subject, and said it succeeded.**
Naming a source that did not resolve got you a silently substituted different source, a confident answer
about it, and exit 0. An explicit input that cannot be read is now `UNAVAILABLE` (exit 2) — never replaced,
and never conflated with "the subject was read and breached" (exit 1). Discovery applies only when no
explicit input was given, and the winning strategy is disclosed in the output, so a reader can always tell
which rule applied.

**The deprecation check had no registry to check.**
Against a public checkout before this commit the default invocation exits 2 — there was nothing to read.
`governance/DEPRECATIONS.md` is added as the public registry, and the checker takes an injectable subject
and names it. The default now returns a real verdict over a real population.

## Scope

Two items. Four files: two scripts, one new registry, one new test contract.

Deliberately **not** included: the value-candidate filter and the plan-template currency fix. Both are
verified, both are retained privately, and neither is claimed as delivered here — their public targets
either do not exist or are generations apart from the private ones, which would have made shipping them a
much larger change than a corrective release should carry.

## Verification

Measured on this candidate under identical conditions, not inherited:

| | passed | skipped | failed |
|---|---:|---:|---:|
| base | 539 | 11 | 0 |
| this branch | 548 | 10 | 0 |

Nine new passing tests, zero new failures. The payload contract suite runs 8/8 with no skips.