### PR TITLE
docs: correct the [Unreleased] latest-released pointer to 3.33.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@ Two repairs to controls that report on releases. Both failed at their shipped pu
 
 ## [Unreleased]
 
-Items confirmed in-flight for a future release (latest released: **3.31.1**). Per Keep a Changelog 1.1.0 forward-work convention.
+Items confirmed in-flight for a future release (latest released: **3.33.1**). Per Keep a Changelog 1.1.0 forward-work convention.
 
 - Issue-governance spec delta for the `/aget-file-issue` pre-filing probes (skill layer shipped in 3.26.0; formal requirement rides the next spec pass).
 - Template `/aget-file-issue` structural refresh (routing + probe steps to all templates; fleet routing propagation staged per the 3.26.0 rollout decision).


### PR DESCRIPTION
The `[Unreleased]` block still names **3.31.1** as the latest release. Three releases have shipped since — 3.32.0 (2026-08-24), 3.33.0 (2026-08-30) and 3.33.1 (2026-08-31, current).

**One token changed.** No release entry, in-flight item, or unrelated content touched.

Governing predicate (R-REL-019 deliverable leg, `check_release_completion.sh`):

```
grep -A4 '## [Unreleased]' CHANGELOG.md | grep -q '3.33.1'
```

Verified FAILING at the published source before the edit. It is one of the blocking legs holding v3.33.x release-plan closure, which in turn holds the Phase 0.99 prior-version ratchet for the v3.34 cycle.

Historical correction, explicitly authorized by the principal for Tuesday 2026-09-08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KxLjK1GBX4HSZoKxVvewn1